### PR TITLE
worldGuard Tags

### DIFF
--- a/bukkit/src/main/java/com/denizenscript/depenizen/bukkit/extensions/worldguard/WorldGuardPlayerExtension.java
+++ b/bukkit/src/main/java/com/denizenscript/depenizen/bukkit/extensions/worldguard/WorldGuardPlayerExtension.java
@@ -1,0 +1,84 @@
+package com.denizenscript.depenizen.bukkit.extensions.worldguard;
+
+import com.denizenscript.depenizen.bukkit.extensions.dObjectExtension;
+import com.denizenscript.depenizen.bukkit.support.Support;
+import com.denizenscript.depenizen.bukkit.support.plugins.WorldGuardSupport;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.DefaultFlag;
+
+import net.aufdemrand.denizen.objects.dLocation;
+import net.aufdemrand.denizen.objects.dPlayer;
+import net.aufdemrand.denizencore.objects.Element;
+import net.aufdemrand.denizencore.objects.dObject;
+import net.aufdemrand.denizencore.tags.Attribute;
+
+import org.bukkit.entity.Player;
+
+public class WorldGuardPlayerExtension extends dObjectExtension {
+
+    public static boolean describes(dObject object) {
+        return object instanceof dPlayer
+                && ((dPlayer) object).isOnline();
+    }
+
+    public static WorldGuardPlayerExtension getFrom(dObject object) {
+        if (!describes(object)) {
+            return null;
+        }
+        return new WorldGuardPlayerExtension((dPlayer) object);
+    }
+
+    private WorldGuardPlayerExtension(dPlayer player) {
+        this.player = player.getPlayerEntity();
+        this.wgp = Support.getPlugin(WorldGuardSupport.class);
+    }
+
+    Player player = null;
+    WorldGuardPlugin wgp = null;
+
+    private ApplicableRegionSet getApplicableRegions() {
+        return wgp.getRegionManager(player.getWorld()).getApplicableRegions(player.getLocation());
+    }
+
+    @Override
+    public String getAttribute(Attribute attribute) {
+
+        // <--[tag]
+        // @attribute <p@player.can_build[<l@location>]>
+        // @returns Element(Boolean)
+        // @description
+        // Whether WorldGuard allows to build at a location.
+        // @Plugin DepenizenBukkit, WorldGuard
+        // -->
+        if (attribute.startsWith("can_build") && attribute.hasContext(1)) {
+            dLocation location = dLocation.valueOf(attribute.getContext(1));
+            if (location == null ) {
+                return null;
+            }
+            if (wgp.canBuild(player, location)) {
+                return Element.TRUE.getAttribute(attribute.fulfill(1));
+            }
+            return Element.FALSE.getAttribute(attribute.fulfill(1));
+        }
+
+        // <--[tag]
+        // @attribute <p@player.can_pvp>
+        // @returns Element(Boolean)
+        // @description
+        // Whether WorldGuard allows to pvp at the players location.
+        // @Plugin DepenizenBukkit, WorldGuard
+        // -->
+        if (attribute.startsWith("can_pvp")) {
+            ApplicableRegionSet set = getApplicableRegions();
+            if (set.testState(wgp.wrapPlayer(player), DefaultFlag.PVP)) {
+                return Element.TRUE.getAttribute(attribute.fulfill(1));
+            }
+            return Element.FALSE.getAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+
+    }
+
+}

--- a/bukkit/src/main/java/com/denizenscript/depenizen/bukkit/extensions/worldguard/WorldGuardPlayerExtension.java
+++ b/bukkit/src/main/java/com/denizenscript/depenizen/bukkit/extensions/worldguard/WorldGuardPlayerExtension.java
@@ -46,9 +46,9 @@ public class WorldGuardPlayerExtension extends dObjectExtension {
     }
 
     // The original flag-reference without fuzziness
-    private StateFlag getStateFlag(String string) {
+    private StateFlag getStateFlag(String s) {
         for (Flag<?> flag : DefaultFlag.getFlags()) {
-            if (flag.getName().equalsIgnoreCase(string)) {
+            if (flag instanceof StateFlag && flag.getName().equalsIgnoreCase(s)) {
                 return (StateFlag) flag;
             }
         }

--- a/bukkit/src/main/java/com/denizenscript/depenizen/bukkit/support/plugins/WorldGuardSupport.java
+++ b/bukkit/src/main/java/com/denizenscript/depenizen/bukkit/support/plugins/WorldGuardSupport.java
@@ -6,10 +6,12 @@ import com.denizenscript.depenizen.bukkit.extensions.worldguard.WorldGuardWorldE
 import com.denizenscript.depenizen.bukkit.support.Support;
 import net.aufdemrand.denizen.objects.dCuboid;
 import net.aufdemrand.denizen.objects.dLocation;
+import net.aufdemrand.denizen.objects.dPlayer;
 import net.aufdemrand.denizen.objects.dWorld;
 import net.aufdemrand.denizencore.tags.TagContext;
 import net.aufdemrand.denizencore.tags.Attribute;
 import com.denizenscript.depenizen.bukkit.extensions.worldguard.WorldGuardLocationExtension;
+import com.denizenscript.depenizen.bukkit.extensions.worldguard.WorldGuardPlayerExtension;
 import com.denizenscript.depenizen.bukkit.objects.worldguard.WorldGuardRegion;
 
 public class WorldGuardSupport extends Support {
@@ -17,6 +19,7 @@ public class WorldGuardSupport extends Support {
     public WorldGuardSupport() {
         registerObjects(WorldGuardRegion.class);
         registerProperty(WorldGuardLocationExtension.class, dLocation.class);
+        registerProperty(WorldGuardPlayerExtension.class, dPlayer.class);
         registerProperty(WorldGuardCuboidExtension.class, dCuboid.class);
         registerProperty(WorldGuardWorldExtension.class, dWorld.class);
         new RegionCommand().activate().as("REGION").withOptions("See Documentation.", 2);


### PR DESCRIPTION
Hey. I tested a bit arround these tags, as I want to use them in the future.
They can be used to check whether the player is allowed to use scripted weapons or build tools.
So I ended with these two tags:
```
<p@player.can_build[<l@location>]>  - Can the player build at this location ?
<p@player.can_pvp>                  - Can the player make pvp at his location ?
```
Anyone may want to review the code, so we can get it to a usable state ?


