### PR TITLE
Shopkeeper update for snapshot v2.1.1

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -310,7 +310,7 @@
         </dependency>
         <dependency>
             <groupId>com.nisovin.shopkeepers</groupId>
-            <artifactId>ShopkeepersAPI</artifactId>
+            <artifactId>Shopkeepers</artifactId>
             <version>2.1.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -33,10 +33,16 @@
         <repository>
             <id>shopkeepers-releases</id>
             <url>http://nexus3.cube-nation.de/repository/releases/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>shopkeepers-snapshots</id>
             <url>http://nexus3.cube-nation.de/repository/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
         <!--
         <repository>

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -310,8 +310,8 @@
         </dependency>
         <dependency>
             <groupId>com.nisovin.shopkeepers</groupId>
-            <artifactId>Shopkeepers</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
+            <artifactId>ShopkeepersAPI</artifactId>
+            <version>2.1.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -31,7 +31,11 @@
             <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
         <repository>
-            <id>shopkeepers</id>
+            <id>shopkeepers-releases</id>
+            <url>http://nexus3.cube-nation.de/repository/releases/</url>
+        </repository>
+        <repository>
+            <id>shopkeepers-snapshots</id>
             <url>http://nexus3.cube-nation.de/repository/snapshots/</url>
         </repository>
         <!--
@@ -311,7 +315,7 @@
         <dependency>
             <groupId>com.nisovin.shopkeepers</groupId>
             <artifactId>Shopkeepers</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>2.2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bukkit/src/main/java/com/denizenscript/depenizen/bukkit/objects/shopkeepers/ShopKeeper.java
+++ b/bukkit/src/main/java/com/denizenscript/depenizen/bukkit/objects/shopkeepers/ShopKeeper.java
@@ -7,7 +7,6 @@ import com.nisovin.shopkeepers.api.shopkeeper.TradingRecipe;
 import com.nisovin.shopkeepers.api.ShopkeepersAPI;
 import com.nisovin.shopkeepers.api.ShopkeepersPlugin;
 import com.nisovin.shopkeepers.api.shopobjects.entity.EntityShopObject;
-
 import net.aufdemrand.denizen.objects.dEntity;
 import net.aufdemrand.denizen.objects.dItem;
 import net.aufdemrand.denizencore.objects.Element;

--- a/bukkit/src/main/java/com/denizenscript/depenizen/bukkit/objects/shopkeepers/ShopKeeper.java
+++ b/bukkit/src/main/java/com/denizenscript/depenizen/bukkit/objects/shopkeepers/ShopKeeper.java
@@ -6,7 +6,8 @@ import com.nisovin.shopkeepers.api.shopkeeper.Shopkeeper;
 import com.nisovin.shopkeepers.api.shopkeeper.TradingRecipe;
 import com.nisovin.shopkeepers.api.ShopkeepersAPI;
 import com.nisovin.shopkeepers.api.ShopkeepersPlugin;
-import com.nisovin.shopkeepers.api.shopobjects.ShopObject;
+import com.nisovin.shopkeepers.api.shopobjects.entity.EntityShopObject;
+
 import net.aufdemrand.denizen.objects.dEntity;
 import net.aufdemrand.denizen.objects.dItem;
 import net.aufdemrand.denizencore.objects.Element;
@@ -17,8 +18,6 @@ import net.aufdemrand.denizencore.tags.Attribute;
 import net.aufdemrand.denizencore.tags.TagContext;
 import net.aufdemrand.denizencore.tags.core.EscapeTags;
 import net.aufdemrand.denizencore.utilities.debugging.dB;
-import net.citizensnpcs.api.CitizensAPI;
-import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.inventory.ItemStack;
@@ -68,38 +67,6 @@ public class ShopKeeper implements dObject {
         return new ShopKeeper(ShopkeepersAPI.getShopkeeperRegistry().getShopkeeperByEntity(entity.getBukkitEntity()));
     }
 
-    public static Entity getEntity(Shopkeeper keeper) {
-        try {
-            ShopObject obj = keeper.getShopObject();
-            if (obj == null) {
-                return null;
-            }
-            String id = obj.getId();
-            if (id == null) {
-                return null;
-            }
-            if (obj == ShopkeepersAPI.getDefaultShopObjectTypes().getCitizensShopObjectType()) { // For lack of equals() or is*() API options...
-                if (id.startsWith("NPC-")) { // For lack of getInternalRepresentation API options...
-                    int idNum = Integer.parseInt(id.substring("NPC-".length()));
-                    NPC npc = CitizensAPI.getNPCRegistry().getById(idNum); // This is entirely wrong - NPCs are not guaranteed unique on their integer ID. But it's all we have.
-                    if (npc.isSpawned()) {
-                        return npc.getEntity();
-                    }
-                    return null;
-                }
-            }
-            if (id.startsWith("entity")) {
-                UUID uuid = UUID.fromString(id.substring("entity".length()));
-                return dEntity.getEntityForID(uuid);
-            }
-        }
-        catch (Exception ex) {
-            dB.echoError("Failed while searching entity for Shopkeeper: " + keeper);
-            dB.echoError(ex);
-        }
-        return null;
-    }
-
     public ShopKeeper(Shopkeeper shopkeeper) {
         if (shopkeeper != null) {
             this.shopkeeper = shopkeeper;
@@ -121,7 +88,10 @@ public class ShopKeeper implements dObject {
     }
 
     public Entity getBukkitEntity() {
-        return getEntity(shopkeeper);
+        if (shopkeeper.getShopObject() instanceof EntityShopObject) {
+            return ((EntityShopObject) shopkeeper.getShopObject()).getEntity();
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
The Shopkeepers API now directly supports getting an shopkeeper's entity (not yet tested though).

Switched the dependency back to use 'ShopkeepersAPI' (should contain a few less transitive/unneeded dependencies).
This depends on the latest snapshot build of shopkeepers (so this will not work with the currently released version of Shopkeepers). It might therefore make sense to postpone the merging of this PR until the next version of Shopkeepers is actually released, and then also switch the dependency and repository from 'snapshots' to 'releases'.

Edit: Also, since the Shopkeeper dependency is now downloaded from the repository, it can probably be removed from the lib folder. Otherwise it would need to be updated there as well to match again.