### PR TITLE
Add return after cuboid_to_clipboard in worldedit

### DIFF
--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/worldedit/WorldEditCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/worldedit/WorldEditCommand.java
@@ -335,6 +335,7 @@ public class WorldEditCommand extends AbstractCommand {
                 }
                 ClipboardHolder holder = new ClipboardHolder(clipboard);
                 WorldEdit.getInstance().getSessionManager().get(p).setClipboard(holder);
+                return;
             }
             if (file == null) {
                 Debug.echoError("Cuboid or file must be specified.");


### PR DESCRIPTION
Fixes file arg error for worldedit when copying cuboid to clipboard.