### PR TITLE
Add new Quests command

### DIFF
--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/QuestsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/QuestsBridge.java
@@ -27,7 +27,7 @@ public class QuestsBridge extends Bridge {
         instance = this;
         PropertyParser.registerProperty(QuestsPlayerProperties.class, PlayerTag.class);
         DenizenAPI.getCurrentInstance().getCommandRegistry().registerCoreMember(QuestsCommand.class, "QUESTS",
-                "quests [add/remove/set] (quest-id:<quest-id>) (stage-no:<#>) (points:<#>) (state:true/false)", 1);
+                "quests [add/remove/set] (quest_id:<quest-id>) (stage_no:<#>) (points:<#>) (state:true/false)", 1);
         ScriptEvent.registerScriptEvent(new PlayerCompletesQuestScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerFailsQuestScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerStartsQuestScriptEvent());

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/QuestsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/QuestsBridge.java
@@ -11,7 +11,9 @@ import com.denizenscript.depenizen.bukkit.events.quests.PlayerFailsQuestScriptEv
 import com.denizenscript.depenizen.bukkit.events.quests.PlayerStartsQuestScriptEvent;
 import com.denizenscript.depenizen.bukkit.properties.quests.QuestsPlayerProperties;
 import com.denizenscript.depenizen.bukkit.Bridge;
+import com.denizenscript.depenizen.bukkit.commands.quests.QuestsCommand;
 import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.DenizenAPI;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import me.blackvein.quests.Quest;
 import me.blackvein.quests.Quests;
@@ -24,6 +26,8 @@ public class QuestsBridge extends Bridge {
     public void init() {
         instance = this;
         PropertyParser.registerProperty(QuestsPlayerProperties.class, PlayerTag.class);
+        DenizenAPI.getCurrentInstance().getCommandRegistry().registerCoreMember(QuestsCommand.class, "QUESTS",
+                "quests [add/remove/set] (quest-id:<quest-id>) (stage-no:<#>) (points:<#>) (state:true/false)", 1);
         ScriptEvent.registerScriptEvent(new PlayerCompletesQuestScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerFailsQuestScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerStartsQuestScriptEvent());

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/QuestsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/QuestsBridge.java
@@ -27,7 +27,7 @@ public class QuestsBridge extends Bridge {
         instance = this;
         PropertyParser.registerProperty(QuestsPlayerProperties.class, PlayerTag.class);
         DenizenAPI.getCurrentInstance().getCommandRegistry().registerCoreMember(QuestsCommand.class, "QUESTS",
-                "quests [add/remove/set] (quest_id:<quest-id>) (stage_no:<#>) (points:<#>) (state:true/false)", 1);
+                "quests [add/remove/set] (quest_id:<quest-id>) (stage:<#>) (points:<#>) (state:true/false)", 1);
         ScriptEvent.registerScriptEvent(new PlayerCompletesQuestScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerFailsQuestScriptEvent());
         ScriptEvent.registerScriptEvent(new PlayerStartsQuestScriptEvent());

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -33,7 +33,9 @@ public class QuestsCommand extends AbstractCommand {
     //
     // @Description
     // This command allows you to give, quit, or set the stage of a quest for a player, or to add, subtract, or set
-    // the amount of Quest Points that a player holds.
+    // the amount of Quest Points that a player holds. When modifying quests, the ID (read: NOT the name) must be
+    // specified. Numerical stage number must be present when setting progress. State indicates whether to perform
+    // associated checks (see Usage). If not modifying a quest, points must be included as a numerical value.
     //
     // @Tags
     // None

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -39,15 +39,15 @@ public class QuestsCommand extends AbstractCommand {
     // None
     //
     // @Usage
-    // Use to force player to take MyFirstQuest quest, ignoring requirements.
+    // Use to force player to take quest with ID custom1, ignoring requirements.
     // - quests add quest_id:custom1 state:true
     //
     // @Usage
-    // Use to force player to quit MyFirstQuest quest, notifying player.
+    // Use to force player to quit quest with ID custom2, notifying player.
     // - quests remove quest_id:custom2 state:true
     //
     // @Usage
-    // Use to force player into specified stage 2 of MyFirstQuest quest.
+    // Use to force player into specified stage 2 of quest with ID custom3.
     // - quests set quest_id:custom3 stage_no:2
     //
     // @Usage

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -118,7 +118,6 @@ public class QuestsCommand extends AbstractCommand {
         
         BukkitScriptEntryData scriptEntryData = (BukkitScriptEntryData) scriptEntry.entryData;
 
-        // Get objects
         ElementTag action = scriptEntry.getElement("action");
         ElementTag questId = scriptEntry.getElement("quest_id");
         ElementTag stageNum = scriptEntry.getElement("stage_no");
@@ -127,7 +126,6 @@ public class QuestsCommand extends AbstractCommand {
 
         PlayerTag player = scriptEntryData.getPlayer();
 
-        // Report to dB
         Debug.report(scriptEntry, getName(), action.debug() 
                 + (questId != null ? questId.debug() : "") 
                 + (stageNum != null ? stageNum.debug() : "") 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -131,8 +131,7 @@ public class QuestsCommand extends AbstractCommand {
             Debug.report(scriptEntry, getName(), action.debug() 
                     + (questId != null ? questId.debug() : "") 
                     + (stageNum != null ? stageNum.debug() : "") 
-                    + (points != null ? points.debug() : "") 
-                    + (state != null ? state.debug() : ""));
+                    + (points != null ? points.debug() : ""));
         }
 
         switch (Action.valueOf(action.asString().toUpperCase())) {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -126,11 +126,13 @@ public class QuestsCommand extends AbstractCommand {
 
         PlayerTag player = scriptEntryData.getPlayer();
 
-        Debug.report(scriptEntry, getName(), action.debug() 
-                + (questId != null ? questId.debug() : "") 
-                + (stageNum != null ? stageNum.debug() : "") 
-                + (points != null ? points.debug() : "") 
-                + (state != null ? state.debug() : ""));
+        if (scriptEntry.dbCallShouldDebug()) {
+            Debug.report(scriptEntry, getName(), action.debug() 
+                    + (questId != null ? questId.debug() : "") 
+                    + (stageNum != null ? stageNum.debug() : "") 
+                    + (points != null ? points.debug() : "") 
+                    + (state != null ? state.debug() : ""));
+        }
 
         switch (Action.valueOf(action.asString().toUpperCase())) {
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -159,11 +159,11 @@ public class QuestsCommand extends AbstractCommand {
                 if (questId != null && state != null) {
                     for (Quest quest : quests.getQuests()) {
                         if (quest.getId().equals(questId.asString()) && player != null) {
-                            Player p = player.getPlayerEntity();
-                            Quester quester = quests.getQuester(p.getUniqueId());
+                            Player thePlayer = player.getPlayerEntity();
+                            Quester quester = quests.getQuester(thePlayer.getUniqueId());
                             quester.hardQuit(quest);
-                            if (state.asBoolean() && p.isOnline()) {
-                                p.sendMessage(Lang.get(p, "questQuit").replace("<quest>", quest.getName()));
+                            if (state.asBoolean() && thePlayer.isOnline()) {
+                                thePlayer.sendMessage(Lang.get(thePlayer, "questQuit").replace("<quest>", quest.getName()));
                             }
                             reloadData(quester);
                             quester.updateJournal();

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -14,6 +14,7 @@ import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import org.bukkit.entity.Player;
 
 import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.debugging.Debug;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -122,7 +123,7 @@ public class QuestsCommand extends AbstractCommand {
         ElementTag points = scriptEntry.getElement("points");
         ElementTag state = scriptEntry.getElement("state");
 
-        PlayerTag player = ((BukkitScriptEntryData) scriptEntry.entryData).getPlayer();
+        PlayerTag player = Utilities.getEntryPlayer(scriptEntry);
 
         if (scriptEntry.dbCallShouldDebug()) {
             Debug.report(scriptEntry, getName(), action.debug() 
@@ -139,6 +140,7 @@ public class QuestsCommand extends AbstractCommand {
                 if (questId != null && state != null) {
                     for (Quest quest : quests.getQuests()) {
                         if (quest.getId().equals(questId.asString()) && player != null) {
+                            
                             quests.getQuester(player.getPlayerEntity().getUniqueId()).takeQuest(quest, state.asBoolean());
                             break;
                         }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -214,7 +214,9 @@ public class QuestsCommand extends AbstractCommand {
     }
     
     private void reloadData(Quester quester) {
-        if (quester == null) return;
+        if (quester == null) {
+            return;
+        }
         quester.saveData();
         quester.loadData();
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -162,7 +162,7 @@ public class QuestsCommand extends AbstractCommand {
                             Player p = player.getPlayerEntity();
                             Quester quester = quests.getQuester(p.getUniqueId());
                             quester.hardQuit(quest);
-                            if (state.asBoolean() == true && p.isOnline()) {
+                            if (state.asBoolean() && p.isOnline()) {
                                 p.sendMessage(Lang.get(p, "questQuit").replace("<quest>", quest.getName()));
                             }
                             reloadData(quester);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -115,8 +115,6 @@ public class QuestsCommand extends AbstractCommand {
     @Override
     public void execute(ScriptEntry scriptEntry) {
         Quests quests = (Quests) QuestsBridge.instance.plugin;
-        
-        BukkitScriptEntryData scriptEntryData = (BukkitScriptEntryData) scriptEntry.entryData;
 
         ElementTag action = scriptEntry.getElement("action");
         ElementTag questId = scriptEntry.getElement("quest_id");
@@ -124,7 +122,7 @@ public class QuestsCommand extends AbstractCommand {
         ElementTag points = scriptEntry.getElement("points");
         ElementTag state = scriptEntry.getElement("state");
 
-        PlayerTag player = scriptEntryData.getPlayer();
+        PlayerTag player = ((BukkitScriptEntryData) scriptEntry.entryData).getPlayer();
 
         if (scriptEntry.dbCallShouldDebug()) {
             Debug.report(scriptEntry, getName(), action.debug() 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -129,7 +129,8 @@ public class QuestsCommand extends AbstractCommand {
             Debug.report(scriptEntry, getName(), action.debug() 
                     + (questId != null ? questId.debug() : "") 
                     + (stageNum != null ? stageNum.debug() : "") 
-                    + (points != null ? points.debug() : ""));
+                    + (points != null ? points.debug() : "")
+                    + state.debug());
         }
 
         switch (Action.valueOf(action.asString().toUpperCase())) {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -148,7 +148,8 @@ public class QuestsCommand extends AbstractCommand {
                     Quester quester = quests.getQuester(player.getPlayerEntity().getUniqueId());
                     quester.setQuestPoints(quester.getQuestPoints() + points.asInt());
                     reloadData(quester);
-                } else {
+                } 
+                else {
                     Debug.echoError("Must specify either a quest_id and state value, or a points value.");
                 }
                 
@@ -177,7 +178,8 @@ public class QuestsCommand extends AbstractCommand {
                     int n = quester.getQuestPoints() - points.asInt();
                     quester.setQuestPoints(n <= 0 ? 0 : n);
                     reloadData(quester);
-                } else {
+                } 
+                else {
                     Debug.echoError("Must specify either a quest_id and state value, or a points value.");
                 }
                 
@@ -191,7 +193,8 @@ public class QuestsCommand extends AbstractCommand {
                         if (quest.getId().equals(questId.asString()) && player != null) {
                             try {
                                 quest.setStage(quests.getQuester(player.getPlayerEntity().getUniqueId()), stageNum.asInt());
-                            } catch (InvalidStageException e) {
+                            } 
+                            catch (InvalidStageException e) {
                                 e.printStackTrace();
                             }
                             break;
@@ -202,7 +205,8 @@ public class QuestsCommand extends AbstractCommand {
                     Quester quester = quests.getQuester(player.getPlayerEntity().getUniqueId());
                     quester.setQuestPoints(points.asInt());
                     reloadData(quester);
-                } else {
+                }
+                else {
                     Debug.echoError("Must specify either a quest_id and stage_no value, or a points value.");
                 }
                 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -9,8 +9,6 @@ import me.blackvein.quests.Quests;
 import me.blackvein.quests.exceptions.InvalidStageException;
 import me.blackvein.quests.util.Lang;
 
-import org.bukkit.entity.Player;
-
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizen.utilities.debugging.Debug;
@@ -162,11 +160,10 @@ public class QuestsCommand extends AbstractCommand {
                 if (questId != null && state != null) {
                     for (Quest quest : quests.getQuests()) {
                         if (quest.getId().equals(questId.asString())) {
-                            Player thePlayer = player.getPlayerEntity();
-                            Quester quester = quests.getQuester(thePlayer.getUniqueId());
+                            Quester quester = quests.getQuester(player.getPlayerEntity().getUniqueId());
                             quester.hardQuit(quest);
-                            if (state.asBoolean() && thePlayer.isOnline()) {
-                                thePlayer.sendMessage(Lang.get(thePlayer, "questQuit").replace("<quest>", quest.getName()));
+                            if (state.asBoolean() && player.isOnline()) {
+                                player.getPlayerEntity().sendMessage(Lang.get(player.getPlayerEntity(), "questQuit").replace("<quest>", quest.getName()));
                             }
                             reloadData(quester);
                             quester.updateJournal();

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -21,11 +21,6 @@ import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.depenizen.bukkit.bridges.QuestsBridge;
 
-/**
- * Command integration for Quests
- * @author PikaMug
- * @since 2.0.0-b595
- */
 public class QuestsCommand extends AbstractCommand {
 
     // <--[command]

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -9,8 +9,6 @@ import me.blackvein.quests.Quests;
 import me.blackvein.quests.exceptions.InvalidStageException;
 import me.blackvein.quests.util.Lang;
 
-import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
-
 import org.bukkit.entity.Player;
 
 import com.denizenscript.denizen.objects.PlayerTag;
@@ -105,6 +103,10 @@ public class QuestsCommand extends AbstractCommand {
             }
 
         }
+        
+        if (!Utilities.entryHasPlayer(scriptEntry)) {
+            throw new InvalidArgumentsException("Must have a linked player!");
+        }
 
         if (!scriptEntry.hasObject("action")) {
             throw new InvalidArgumentsException("Must specify a valid action!");
@@ -139,7 +141,7 @@ public class QuestsCommand extends AbstractCommand {
 
                 if (questId != null && state != null) {
                     for (Quest quest : quests.getQuests()) {
-                        if (quest.getId().equals(questId.asString()) && player != null) {
+                        if (quest.getId().equals(questId.asString())) {
                             
                             quests.getQuester(player.getPlayerEntity().getUniqueId()).takeQuest(quest, state.asBoolean());
                             break;
@@ -160,7 +162,7 @@ public class QuestsCommand extends AbstractCommand {
                 
                 if (questId != null && state != null) {
                     for (Quest quest : quests.getQuests()) {
-                        if (quest.getId().equals(questId.asString()) && player != null) {
+                        if (quest.getId().equals(questId.asString())) {
                             Player thePlayer = player.getPlayerEntity();
                             Quester quester = quests.getQuester(thePlayer.getUniqueId());
                             quester.hardQuit(quest);
@@ -188,7 +190,7 @@ public class QuestsCommand extends AbstractCommand {
 
                 if (questId != null && stageNum != null && stageNum.asInt() > 0) {
                     for (Quest quest : quests.getQuests()) {
-                        if (quest.getId().equals(questId.asString()) && player != null) {
+                        if (quest.getId().equals(questId.asString())) {
                             try {
                                 quest.setStage(quests.getQuester(player.getPlayerEntity().getUniqueId()), stageNum.asInt());
                             } 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -150,6 +150,8 @@ public class QuestsCommand extends AbstractCommand {
                     Quester quester = quests.getQuester(player.getPlayerEntity().getUniqueId());
                     quester.setQuestPoints(quester.getQuestPoints() + points.asInt());
                     reloadData(quester);
+                } else {
+                    Debug.echoError("Must specify either a quest_id and state value, or a points value.");
                 }
                 
                 break;
@@ -177,6 +179,8 @@ public class QuestsCommand extends AbstractCommand {
                     int n = quester.getQuestPoints() - points.asInt();
                     quester.setQuestPoints(n <= 0 ? 0 : n);
                     reloadData(quester);
+                } else {
+                    Debug.echoError("Must specify either a quest_id and state value, or a points value.");
                 }
                 
                 break;
@@ -200,6 +204,8 @@ public class QuestsCommand extends AbstractCommand {
                     Quester quester = quests.getQuester(player.getPlayerEntity().getUniqueId());
                     quester.setQuestPoints(points.asInt());
                     reloadData(quester);
+                } else {
+                    Debug.echoError("Must specify either a quest_id and stage_no value, or a points value.");
                 }
                 
                 break;

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -1,0 +1,221 @@
+package com.denizenscript.depenizen.bukkit.commands.quests;
+
+import com.denizenscript.denizencore.objects.Argument;
+import com.denizenscript.denizencore.objects.ArgumentHelper;
+
+import me.blackvein.quests.Quest;
+import me.blackvein.quests.Quester;
+import me.blackvein.quests.Quests;
+import me.blackvein.quests.exceptions.InvalidStageException;
+import me.blackvein.quests.util.Lang;
+
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+
+import org.bukkit.entity.Player;
+
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.debugging.Debug;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.depenizen.bukkit.bridges.QuestsBridge;
+
+/**
+ * Command integration for Quests
+ * @author PikaMug
+ * @since 2.0.0-b595
+ */
+public class QuestsCommand extends AbstractCommand {
+
+    // <--[command]
+    // @Name Quests
+    // @Syntax quests [add/remove/set] (questId:<quest-id>) (stage-no:<#>) (points:<#>) (state:true/false)
+    // @Group Depenizen
+    // @Plugin Depenizen, Quests
+    // @Required 1
+    // @Short Edits quest player information.
+    //
+    // @Description
+    // This command allows you to give, quit, or set the stage of a quest for a player, or to add, subtract, or set
+    // the amount of Quest Points that a player holds.
+    //
+    // @Tags
+    // None
+    //
+    // @Usage
+    // Use to force player to take MyFirstQuest quest, ignoring requirements.
+    // - quests add quest-id:custom1 state:true
+    //
+    // @Usage
+    // Use to force player to quit MyFirstQuest quest, notifying player.
+    // - quests remove quest-id:custom2 state:true
+    //
+    // @Usage
+    // Use to force player into specified stage 2 of MyFirstQuest quest.
+    // - quests set quest-id:custom3 stage-no:2
+    //
+    // @Usage
+    // Use to give player 100 Quest Points.
+    // - quests add points:100
+    //
+    // -->
+
+    private enum Action {ADD, REMOVE, SET}
+    
+    private enum State {TRUE, FALSE}
+
+    public QuestsCommand() {
+
+    }
+
+    @Override
+    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
+
+        // Iterate through arguments
+        for (Argument arg : scriptEntry.getProcessedArgs()) {
+
+            if (!scriptEntry.hasObject("action")
+                    && arg.matchesEnum(Action.values())) {
+                scriptEntry.addObject("action", arg.asElement());
+            }
+
+            else if (!scriptEntry.hasObject("quest-id")
+                    && arg.matchesPrefix("quest", "quest-id")) {
+                scriptEntry.addObject("quest-id", arg.asElement());
+            }
+            
+            else if (!scriptEntry.hasObject("stage-no")
+                    && arg.matchesPrefix("stage", "stage-no")
+                    && arg.matchesPrimitive(ArgumentHelper.PrimitiveType.Integer)) {
+                scriptEntry.addObject("stage-no", arg.asElement());
+            }
+            
+            else if (!scriptEntry.hasObject("points")
+                    && arg.matchesPrefix("points")
+                    && arg.matchesPrimitive(ArgumentHelper.PrimitiveType.Integer)) {
+                scriptEntry.addObject("points", arg.asElement());
+            }
+            
+            else if (!scriptEntry.hasObject("state")
+                    && arg.matchesPrefix("state")
+                    && arg.matchesEnum(State.values())) {
+                scriptEntry.addObject("state", arg.asElement());
+            }
+            else {
+                arg.reportUnhandled();
+            }
+
+        }
+
+        if (!scriptEntry.hasObject("action")) {
+            throw new InvalidArgumentsException("Must specify a valid action!");
+        }
+        
+        scriptEntry.defaultObject("state", new ElementTag("TRUE"));
+    }
+
+    @Override
+    public void execute(ScriptEntry scriptEntry) {
+        Quests quests = (Quests) QuestsBridge.instance.plugin;
+        
+        BukkitScriptEntryData scriptEntryData = (BukkitScriptEntryData) scriptEntry.entryData;
+
+        // Get objects
+        ElementTag action = scriptEntry.getElement("action");
+        ElementTag questId = scriptEntry.getElement("quest-id");
+        ElementTag stageNum = scriptEntry.getElement("stage-no");
+        ElementTag points = scriptEntry.getElement("points");
+        ElementTag state = scriptEntry.getElement("state");
+
+        PlayerTag player = scriptEntryData.getPlayer();
+
+        // Report to dB
+        Debug.report(scriptEntry, getName(), action.debug() 
+                + (questId != null ? questId.debug() : "") 
+                + (stageNum != null ? stageNum.debug() : "") 
+                + (points != null ? points.debug() : "") 
+                + (state != null ? state.debug() : ""));
+
+        switch (Action.valueOf(action.asString().toUpperCase())) {
+
+            case ADD: {
+
+                if (questId != null && state != null) {
+                    for (Quest quest : quests.getQuests()) {
+                        if (quest.getId().equals(questId.asString()) && player != null) {
+                            quests.getQuester(player.getPlayerEntity().getUniqueId()).takeQuest(quest, state.asBoolean());
+                            break;
+                        }
+                    }
+                }
+                else if (points != null && points.asInt() > 0) {
+                    Quester quester = quests.getQuester(player.getPlayerEntity().getUniqueId());
+                    quester.setQuestPoints(quester.getQuestPoints() + points.asInt());
+                    reloadData(quester);
+                }
+                
+                break;
+
+            }
+            case REMOVE: {
+                
+                if (questId != null && state != null) {
+                    for (Quest quest : quests.getQuests()) {
+                        if (quest.getId().equals(questId.asString()) && player != null) {
+                            Player p = player.getPlayerEntity();
+                            Quester quester = quests.getQuester(p.getUniqueId());
+                            quester.hardQuit(quest);
+                            if (state.asBoolean() == true && p.isOnline()) {
+                                p.sendMessage(Lang.get(p, "questQuit").replace("<quest>", quest.getName()));
+                            }
+                            reloadData(quester);
+                            quester.updateJournal();
+                            break;
+                        }
+                    }
+                }
+                else if (points != null && points.asInt() > 0) {
+                    Quester quester = quests.getQuester(player.getPlayerEntity().getUniqueId());
+                    int n = quester.getQuestPoints() - points.asInt();
+                    quester.setQuestPoints(n <= 0 ? 0 : n);
+                    reloadData(quester);
+                }
+                
+                break;
+                
+            }
+            case SET: {
+
+                if (questId != null && stageNum != null && stageNum.asInt() > 0) {
+                    for (Quest quest : quests.getQuests()) {
+                        if (quest.getId().equals(questId.asString()) && player != null) {
+                            try {
+                                quest.setStage(quests.getQuester(player.getPlayerEntity().getUniqueId()), stageNum.asInt());
+                            } catch (InvalidStageException e) {
+                                e.printStackTrace();
+                            }
+                            break;
+                        }
+                    }
+                }
+                else if (points != null && points.asInt() >= 0) {
+                    Quester quester = quests.getQuester(player.getPlayerEntity().getUniqueId());
+                    quester.setQuestPoints(points.asInt());
+                    reloadData(quester);
+                }
+                
+                break;
+
+            }
+        }
+
+    }
+    
+    private void reloadData(Quester quester) {
+        if (quester == null) return;
+        quester.saveData();
+        quester.loadData();
+    }
+}
+

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -25,7 +25,7 @@ public class QuestsCommand extends AbstractCommand {
 
     // <--[command]
     // @Name Quests
-    // @Syntax quests [add/remove/set] (questId:<quest-id>) (stage-no:<#>) (points:<#>) (state:true/false)
+    // @Syntax quests [add/remove/set] (quest_id:<quest_id>) (stage_no:<#>) (points:<#>) (state:true/false)
     // @Group Depenizen
     // @Plugin Depenizen, Quests
     // @Required 1
@@ -40,15 +40,15 @@ public class QuestsCommand extends AbstractCommand {
     //
     // @Usage
     // Use to force player to take MyFirstQuest quest, ignoring requirements.
-    // - quests add quest-id:custom1 state:true
+    // - quests add quest_id:custom1 state:true
     //
     // @Usage
     // Use to force player to quit MyFirstQuest quest, notifying player.
-    // - quests remove quest-id:custom2 state:true
+    // - quests remove quest_id:custom2 state:true
     //
     // @Usage
     // Use to force player into specified stage 2 of MyFirstQuest quest.
-    // - quests set quest-id:custom3 stage-no:2
+    // - quests set quest_id:custom3 stage_no:2
     //
     // @Usage
     // Use to give player 100 Quest Points.
@@ -75,15 +75,15 @@ public class QuestsCommand extends AbstractCommand {
                 scriptEntry.addObject("action", arg.asElement());
             }
 
-            else if (!scriptEntry.hasObject("quest-id")
-                    && arg.matchesPrefix("quest", "quest-id")) {
-                scriptEntry.addObject("quest-id", arg.asElement());
+            else if (!scriptEntry.hasObject("quest_id")
+                    && arg.matchesPrefix("quest", "quest_id")) {
+                scriptEntry.addObject("quest_id", arg.asElement());
             }
             
-            else if (!scriptEntry.hasObject("stage-no")
-                    && arg.matchesPrefix("stage", "stage-no")
+            else if (!scriptEntry.hasObject("stage_no")
+                    && arg.matchesPrefix("stage", "stage_no")
                     && arg.matchesPrimitive(ArgumentHelper.PrimitiveType.Integer)) {
-                scriptEntry.addObject("stage-no", arg.asElement());
+                scriptEntry.addObject("stage_no", arg.asElement());
             }
             
             else if (!scriptEntry.hasObject("points")
@@ -118,8 +118,8 @@ public class QuestsCommand extends AbstractCommand {
 
         // Get objects
         ElementTag action = scriptEntry.getElement("action");
-        ElementTag questId = scriptEntry.getElement("quest-id");
-        ElementTag stageNum = scriptEntry.getElement("stage-no");
+        ElementTag questId = scriptEntry.getElement("quest_id");
+        ElementTag stageNum = scriptEntry.getElement("stage_no");
         ElementTag points = scriptEntry.getElement("points");
         ElementTag state = scriptEntry.getElement("state");
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -194,8 +194,8 @@ public class QuestsCommand extends AbstractCommand {
                             try {
                                 quest.setStage(quests.getQuester(player.getPlayerEntity().getUniqueId()), stageNum.asInt());
                             } 
-                            catch (InvalidStageException e) {
-                                e.printStackTrace();
+                            catch (InvalidStageException ex) {
+                                Debug.echoError(ex);
                             }
                             break;
                         }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -24,7 +24,7 @@ public class QuestsCommand extends AbstractCommand {
 
     // <--[command]
     // @Name Quests
-    // @Syntax quests [add/remove/set] (quest_id:<quest_id>) (stage_no:<#>) (points:<#>) (state:true/false)
+    // @Syntax quests [add/remove/set] (quest_id:<quest_id>) (stage:<#>) (points:<#>) (state:true/false)
     // @Group Depenizen
     // @Plugin Depenizen, Quests
     // @Required 1
@@ -49,7 +49,7 @@ public class QuestsCommand extends AbstractCommand {
     //
     // @Usage
     // Use to force the player into specified stage 2 of quest with ID custom3.
-    // - quests set quest_id:custom3 stage_no:2
+    // - quests set quest_id:custom3 stage:2
     //
     // @Usage
     // Use to give the player 100 Quest Points.
@@ -81,10 +81,10 @@ public class QuestsCommand extends AbstractCommand {
                 scriptEntry.addObject("quest_id", arg.asElement());
             }
             
-            else if (!scriptEntry.hasObject("stage_no")
-                    && arg.matchesPrefix("stage", "stage_no")
+            else if (!scriptEntry.hasObject("stage")
+                    && arg.matchesPrefix("stage", "stage")
                     && arg.matchesPrimitive(ArgumentHelper.PrimitiveType.Integer)) {
-                scriptEntry.addObject("stage_no", arg.asElement());
+                scriptEntry.addObject("stage", arg.asElement());
             }
             
             else if (!scriptEntry.hasObject("points")
@@ -121,7 +121,7 @@ public class QuestsCommand extends AbstractCommand {
 
         ElementTag action = scriptEntry.getElement("action");
         ElementTag questId = scriptEntry.getElement("quest_id");
-        ElementTag stageNum = scriptEntry.getElement("stage_no");
+        ElementTag stageNum = scriptEntry.getElement("stage");
         ElementTag points = scriptEntry.getElement("points");
         ElementTag state = scriptEntry.getElement("state");
 
@@ -207,7 +207,7 @@ public class QuestsCommand extends AbstractCommand {
                     reloadData(quester);
                 }
                 else {
-                    Debug.echoError("Must specify either a quest_id and stage_no value, or a points value.");
+                    Debug.echoError("Must specify either a quest_id and stage value, or a points value.");
                 }
                 break;
             }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -152,9 +152,7 @@ public class QuestsCommand extends AbstractCommand {
                 else {
                     Debug.echoError("Must specify either a quest_id and state value, or a points value.");
                 }
-                
                 break;
-
             }
             case REMOVE: {
                 
@@ -182,9 +180,7 @@ public class QuestsCommand extends AbstractCommand {
                 else {
                     Debug.echoError("Must specify either a quest_id and state value, or a points value.");
                 }
-                
                 break;
-                
             }
             case SET: {
 
@@ -209,9 +205,7 @@ public class QuestsCommand extends AbstractCommand {
                 else {
                     Debug.echoError("Must specify either a quest_id and stage_no value, or a points value.");
                 }
-                
                 break;
-
             }
         }
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/quests/QuestsCommand.java
@@ -41,19 +41,19 @@ public class QuestsCommand extends AbstractCommand {
     // None
     //
     // @Usage
-    // Use to force player to take quest with ID custom1, ignoring requirements.
+    // Use to force the player to take quest with ID custom1, ignoring requirements.
     // - quests add quest_id:custom1 state:true
     //
     // @Usage
-    // Use to force player to quit quest with ID custom2, notifying player.
+    // Use to force the player to quit quest with ID custom2, notifying said player.
     // - quests remove quest_id:custom2 state:true
     //
     // @Usage
-    // Use to force player into specified stage 2 of quest with ID custom3.
+    // Use to force the player into specified stage 2 of quest with ID custom3.
     // - quests set quest_id:custom3 stage_no:2
     //
     // @Usage
-    // Use to give player 100 Quest Points.
+    // Use to give the player 100 Quest Points.
     // - quests add points:100
     //
     // -->


### PR DESCRIPTION
I have signed the Denizen CLA, although it should be known that https://github.com/DenizenScript/Denizen-For-Bukkit/blob/master/CONTRIBUTING.md#you-agree-by-contributing results in a 404 so I have not seen the full terms. However, I have read and agree to the "Mini-license pre-warning".

This PR adds a command for the free [Quests](https://www.spigotmc.org/resources/quests.3711/) plugin, of which Depenizen already supports a few events. It allows script makers to add/remove/set quest progress or "Quest Points" upon players. I have tested that the command is functional using Denizen-1.1.2-b1700-REL and Quests 3.8.5 (latest).