### PR TITLE
add ViaVersion as softdepend to avoid nags

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -39,6 +39,7 @@ softdepend:
     - Towny
     - TownyChat
     - Vampire
+    - ViaVersion
     - Votifier
     - WorldEdit
     - WorldGuard


### PR DESCRIPTION
console nag:
Loaded class com.denizenscript.depenizen.bukkit.properties.viaversion.ViaVersionPlayerProperties from Depenizen v2.0.0 (build 747) which is not a depend, softdepend or loadbefore of this plugin.

unless there is some reason ViaVersion should not be in plugin.yaml, but we do have viaversion support via 'ViaVersionPlayerProperties.java'