### PR TITLE
Towny and GriefPrevention additions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>me.ryanhamshire</groupId>
             <artifactId>GriefPrevention</artifactId>
-            <version>16.10</version>
+            <version>16.18</version>
             <scope>system</scope>
             <systemPath>${basedir}/lib/GriefPrevention.jar</systemPath>
         </dependency>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/GriefPreventionBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/GriefPreventionBridge.java
@@ -7,6 +7,9 @@ import com.denizenscript.denizencore.tags.ReplaceableTagEvent;
 import com.denizenscript.denizencore.tags.TagManager;
 import com.denizenscript.denizencore.tags.TagRunnable;
 import com.denizenscript.depenizen.bukkit.Bridge;
+import com.denizenscript.depenizen.bukkit.events.griefprevention.GPClaimChangedScriptEvent;
+import com.denizenscript.depenizen.bukkit.events.griefprevention.GPClaimCreatedScriptEvent;
+import com.denizenscript.depenizen.bukkit.events.griefprevention.GPClaimDeletedScriptEvent;
 import com.denizenscript.depenizen.bukkit.properties.griefprevention.GriefPreventionPlayerProperties;
 import com.denizenscript.depenizen.bukkit.objects.griefprevention.GriefPreventionClaimTag;
 import com.denizenscript.denizen.objects.LocationTag;
@@ -28,6 +31,9 @@ public class GriefPreventionBridge extends Bridge {
         PropertyParser.registerProperty(GriefPreventionPlayerProperties.class, PlayerTag.class);
         PropertyParser.registerProperty(GriefPreventionLocationProperties.class, LocationTag.class);
         PropertyParser.registerProperty(GriefPreventionWorldProperties.class, WorldTag.class);
+        ScriptEvent.registerScriptEvent(GPClaimChangedScriptEvent.class);
+        ScriptEvent.registerScriptEvent(GPClaimCreatedScriptEvent.class);
+        ScriptEvent.registerScriptEvent(GPClaimDeletedScriptEvent.class);
         ScriptEvent.registerScriptEvent(GPClaimEnterEvent.class);
         TagManager.registerTagHandler(new TagRunnable.RootForm() {
             @Override

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/GriefPreventionBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/GriefPreventionBridge.java
@@ -1,5 +1,6 @@
 package com.denizenscript.depenizen.bukkit.bridges;
 
+import com.denizenscript.denizen.objects.WorldTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.ReplaceableTagEvent;
@@ -15,6 +16,7 @@ import com.denizenscript.depenizen.bukkit.properties.griefprevention.GriefPreven
 import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.objects.ObjectFetcher;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.denizenscript.depenizen.bukkit.properties.griefprevention.GriefPreventionWorldProperties;
 import me.ryanhamshire.GriefPrevention.Claim;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
 
@@ -25,6 +27,7 @@ public class GriefPreventionBridge extends Bridge {
         ObjectFetcher.registerWithObjectFetcher(GriefPreventionClaimTag.class);
         PropertyParser.registerProperty(GriefPreventionPlayerProperties.class, PlayerTag.class);
         PropertyParser.registerProperty(GriefPreventionLocationProperties.class, LocationTag.class);
+        PropertyParser.registerProperty(GriefPreventionWorldProperties.class, WorldTag.class);
         ScriptEvent.registerScriptEvent(GPClaimEnterEvent.class);
         TagManager.registerTagHandler(new TagRunnable.RootForm() {
             @Override

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/GriefPreventionBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/GriefPreventionBridge.java
@@ -27,7 +27,7 @@ public class GriefPreventionBridge extends Bridge {
 
     @Override
     public void init() {
-        ObjectFetcher.registerWithObjectFetcher(GriefPreventionClaimTag.class);
+        ObjectFetcher.registerWithObjectFetcher(GriefPreventionClaimTag.class, GriefPreventionClaimTag.tagProcessor);
         PropertyParser.registerProperty(GriefPreventionPlayerProperties.class, PlayerTag.class);
         PropertyParser.registerProperty(GriefPreventionLocationProperties.class, LocationTag.class);
         PropertyParser.registerProperty(GriefPreventionWorldProperties.class, WorldTag.class);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/TownyBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/TownyBridge.java
@@ -1,13 +1,14 @@
 package com.denizenscript.depenizen.bukkit.bridges;
 
-import com.denizenscript.depenizen.bukkit.events.towny.PlayerEntersTownScriptEvent;
-import com.denizenscript.depenizen.bukkit.events.towny.PlayerExitsTownScriptEvent;
+import com.denizenscript.denizen.objects.WorldTag;
+import com.denizenscript.depenizen.bukkit.events.towny.*;
 import com.denizenscript.depenizen.bukkit.properties.towny.TownyCuboidProperties;
 import com.denizenscript.depenizen.bukkit.properties.towny.TownyLocationProperties;
 import com.denizenscript.depenizen.bukkit.objects.towny.NationTag;
 import com.denizenscript.depenizen.bukkit.objects.towny.TownTag;
 import com.denizenscript.depenizen.bukkit.Bridge;
 import com.denizenscript.depenizen.bukkit.properties.towny.TownyPlayerProperties;
+import com.denizenscript.depenizen.bukkit.properties.towny.TownyWorldProperties;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
@@ -34,8 +35,12 @@ public class TownyBridge extends Bridge {
         PropertyParser.registerProperty(TownyPlayerProperties.class, PlayerTag.class);
         PropertyParser.registerProperty(TownyLocationProperties.class, LocationTag.class);
         PropertyParser.registerProperty(TownyCuboidProperties.class, CuboidTag.class);
+        PropertyParser.registerProperty(TownyWorldProperties.class, WorldTag.class);
+        ScriptEvent.registerScriptEvent(PlayerClaimsPlotScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerCreatesTownScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerEntersTownScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerExitsTownScriptEvent.class);
+        ScriptEvent.registerScriptEvent(TownCreatedScriptEvent.class);
         TagManager.registerTagHandler(new TagRunnable.RootForm() {
             @Override
             public void run(ReplaceableTagEvent event) {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/griefprevention/GPClaimChangedScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/griefprevention/GPClaimChangedScriptEvent.java
@@ -1,0 +1,87 @@
+package com.denizenscript.depenizen.bukkit.events.griefprevention;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.depenizen.bukkit.objects.griefprevention.GriefPreventionClaimTag;
+import me.ryanhamshire.GriefPrevention.events.ClaimChangeEvent;
+import me.ryanhamshire.GriefPrevention.events.ClaimExtendEvent;
+import me.ryanhamshire.GriefPrevention.events.ClaimResizeEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class GPClaimChangedScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // gp claim changed
+    //
+    // @Cancellable true
+    //
+    // @Triggers when a Grief Prevention claim is modified.
+    //
+    // @Context
+    // <context.old_claim> returns the GriefPreventionClaimTag of the old claim.
+    // <context.new_claim> returns the GriefPreventionClaimTag of the new claim.
+    // <context.source_type> returns the source of the change. Can be: PLAYER, SERVER, or AUTO_DEEPEN.
+    //
+    // @Plugin Depenizen, GriefPrevention
+    //
+    // @Player when source_type is player.
+    //
+    // @Group Depenizen
+    //
+    // -->
+
+    public GPClaimChangedScriptEvent() {
+        instance = this;
+        registerCouldMatcher("gp claim changed");
+    }
+
+    public static GPClaimChangedScriptEvent instance;
+    public ClaimChangeEvent event;
+    public Player player;
+    public String sourceType;
+
+    @Override
+    public String getName() {
+        return "GPClaimChanged";
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(player != null ? PlayerTag.mirrorBukkitPlayer(player) : null, null);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "old_claim":
+                return new GriefPreventionClaimTag(event.getFrom());
+            case "new_claim":
+                return new GriefPreventionClaimTag(event.getTo());
+            case "source_type":
+                return new ElementTag(sourceType);
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onClaimChanged(ClaimChangeEvent event) {
+        this.event = event;
+        this.player = null;
+        this.sourceType = "server";
+        if (event instanceof ClaimExtendEvent) {
+            this.sourceType = "auto_deepen";
+        }
+        else if (event instanceof ClaimResizeEvent && ((ClaimResizeEvent) event).getModifier() instanceof Player) {
+            this.player = (Player) ((ClaimResizeEvent) event).getModifier();
+            this.sourceType = "player";
+        }
+        fire(event);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/griefprevention/GPClaimCreatedScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/griefprevention/GPClaimCreatedScriptEvent.java
@@ -1,0 +1,73 @@
+package com.denizenscript.depenizen.bukkit.events.griefprevention;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.depenizen.bukkit.objects.griefprevention.GriefPreventionClaimTag;
+import me.ryanhamshire.GriefPrevention.events.ClaimCreatedEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class GPClaimCreatedScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // gp claim created
+    //
+    // @Cancellable true
+    //
+    // @Triggers when a Grief Prevention claim is created.
+    //
+    // @Context
+    // <context.claim> returns the GriefPreventionClaimTag that is being created.
+    // <context.source_type> returns the source of the creation. Can be PLAYER or SERVER.
+    //
+    // @Plugin Depenizen, GriefPrevention
+    //
+    // @Player when source_type is player.
+    //
+    // @Group Depenizen
+    //
+    // -->
+
+    public GPClaimCreatedScriptEvent() {
+        instance = this;
+        registerCouldMatcher("gp claim created");
+    }
+
+    public static GPClaimCreatedScriptEvent instance;
+    public ClaimCreatedEvent event;
+    public String sourceType;
+
+    @Override
+    public String getName() {
+        return "GPClaimCreated";
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getCreator() instanceof Player ? PlayerTag.mirrorBukkitPlayer((Player) event.getCreator()) : null, null);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "claim":
+                return new GriefPreventionClaimTag(event.getClaim());
+            case "source_type":
+                return new ElementTag(sourceType);
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onClaimCreated(ClaimCreatedEvent event) {
+        this.event = event;
+        this.sourceType = event.getCreator() instanceof Player ? "player" : "server";
+        fire(event);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/griefprevention/GPClaimDeletedScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/griefprevention/GPClaimDeletedScriptEvent.java
@@ -1,0 +1,53 @@
+package com.denizenscript.depenizen.bukkit.events.griefprevention;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.depenizen.bukkit.objects.griefprevention.GriefPreventionClaimTag;
+import me.ryanhamshire.GriefPrevention.events.ClaimDeletedEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class GPClaimDeletedScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // gp claim deleted
+    //
+    // @Triggers when a Grief Prevention claim is deleted.
+    //
+    // @Context
+    // <context.claim> returns the GriefPreventionClaimTag being deleted.
+    //
+    // @Plugin Depenizen, GriefPrevention
+    //
+    // @Group Depenizen
+    //
+    // -->
+
+    public GPClaimDeletedScriptEvent() {
+        instance = this;
+        registerCouldMatcher("gp claim deleted");
+    }
+
+    public static GPClaimDeletedScriptEvent instance;
+    public ClaimDeletedEvent event;
+
+    @Override
+    public String getName() {
+        return "GPClaimDeleted";
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("claim")) {
+            return new GriefPreventionClaimTag(event.getClaim());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onClaimDeleted(ClaimDeletedEvent event) {
+        this.event = event;
+        fire(event);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerClaimsPlotScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerClaimsPlotScriptEvent.java
@@ -1,0 +1,107 @@
+package com.denizenscript.depenizen.bukkit.events.towny;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.CuboidTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.depenizen.bukkit.objects.towny.TownTag;
+import com.palmergames.bukkit.towny.event.TownPreClaimEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PlayerClaimsPlotScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // towny player claims plot
+    //
+    // @Regex ^on towny player claims plot$
+    //
+    // @Location true
+    //
+    // @Cancellable true
+    //
+    // @Triggers when a player tries to claim a new Towny plot or outpost.
+    //
+    // @Context
+    // <context.is_outpost> Returns whether the new plot is an outpost (not connected to the main town).
+    // <context.is_new_town> Returns whether this is a new town. New towns may not have certain tags available.
+    // <context.town> Returns a TownTag of the town.
+    // <context.cuboid> Returns the cuboid that will be claimed by the town.
+    //
+    // @Determine
+    // "CANCEL_MESSAGE:" + ElementTag to set the message Towny sends when cancelled.
+    //
+    // @Plugin Depenizen, Towny
+    //
+    // @Player Always.
+    //
+    // @Group Depenizen
+    //
+    // -->
+
+    public PlayerClaimsPlotScriptEvent() {
+        instance = this;
+        registerCouldMatcher("towny player claims plot");
+    }
+
+    public static PlayerClaimsPlotScriptEvent instance;
+    public TownPreClaimEvent event;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, event.getPlayer().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public String getName() {
+        return "TownyPlayerClaimsPlot";
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getPlayer());
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "is_outpost":
+                return new ElementTag(event.isOutpost());
+            case "is_new_town":
+                return new ElementTag(event.isHomeBlock());
+            case "town":
+                return new TownTag(event.getTown());
+            case "cuboid":
+                return new CuboidTag(
+                        TownTag.getCornerMin(event.getPlayer().getWorld(), event.getTownBlock().getX(), event.getTownBlock().getZ()),
+                        TownTag.getCornerMax(event.getPlayer().getWorld(), event.getTownBlock().getX(), event.getTownBlock().getZ()));
+        }
+        return super.getContext(name);
+    }
+
+    @Override
+    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
+        if (determinationObj instanceof ElementTag) {
+            String determination = determinationObj.toString();
+            String lower = CoreUtilities.toLowerCase(determination);
+            if (lower.startsWith("cancel_message:")) {
+                event.setCancelMessage(determination.substring("cancel_message:".length()));
+                return true;
+            }
+        }
+        return super.applyDetermination(path, determinationObj);
+    }
+
+    @EventHandler
+    public void onTownyPlayerClaimsPlot(TownPreClaimEvent event) {
+        this.event = event;
+        fire(event);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerClaimsPlotScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerClaimsPlotScriptEvent.java
@@ -79,9 +79,7 @@ public class PlayerClaimsPlotScriptEvent extends BukkitScriptEvent implements Li
             case "town":
                 return new TownTag(event.getTown());
             case "cuboid":
-                return new CuboidTag(
-                        TownTag.getCornerMin(event.getPlayer().getWorld(), event.getTownBlock().getX(), event.getTownBlock().getZ()),
-                        TownTag.getCornerMax(event.getPlayer().getWorld(), event.getTownBlock().getX(), event.getTownBlock().getZ()));
+                return TownTag.getCuboid(event.getPlayer().getWorld(), event.getTownBlock().getX(), event.getTownBlock().getZ());
         }
         return super.getContext(name);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerClaimsPlotScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerClaimsPlotScriptEvent.java
@@ -18,8 +18,6 @@ public class PlayerClaimsPlotScriptEvent extends BukkitScriptEvent implements Li
     // @Events
     // towny player claims plot
     //
-    // @Regex ^on towny player claims plot$
-    //
     // @Location true
     //
     // @Cancellable true

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerCreatesTownScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerCreatesTownScriptEvent.java
@@ -1,0 +1,101 @@
+package com.denizenscript.depenizen.bukkit.events.towny;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.objects.CuboidTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import com.denizenscript.depenizen.bukkit.objects.towny.TownTag;
+import com.palmergames.bukkit.towny.event.PreNewTownEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PlayerCreatesTownScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // towny player creates town
+    //
+    // @Regex ^on towny player creates town$
+    //
+    // @Location true
+    //
+    // @Cancellable true
+    //
+    // @Triggers when a player tries to create a Towny town.
+    //
+    // @Context
+    // <context.town_name> Returns the name of the town the player is creating.
+    // <context.cuboid> Returns the cuboid that will be claimed by the town.
+    //
+    // @Determine
+    // "CANCEL_MESSAGE:" + ElementTag to set the message Towny sends when cancelled.
+    //
+    // @Plugin Depenizen, Towny
+    //
+    // @Player Always.
+    //
+    // @Group Depenizen
+    //
+    // -->
+
+    public PlayerCreatesTownScriptEvent() {
+        instance = this;
+        registerCouldMatcher("towny player creates town");
+    }
+
+    public static PlayerCreatesTownScriptEvent instance;
+    public PreNewTownEvent event;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runInCheck(path, event.getPlayer().getLocation())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public String getName() {
+        return "TownyPlayerCreatesTown";
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getPlayer());
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "town_name":
+                return new ElementTag(event.getTownName());
+            case "cuboid":
+                return new CuboidTag(
+                        TownTag.getCornerMin(event.getTownLocation().getWorld(), event.getTownWorldCoord().getX(), event.getTownWorldCoord().getZ()),
+                        TownTag.getCornerMax(event.getTownLocation().getWorld(), event.getTownWorldCoord().getX(), event.getTownWorldCoord().getZ()));
+        }
+        return super.getContext(name);
+    }
+
+    @Override
+    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
+        if (determinationObj instanceof ElementTag) {
+            String determination = determinationObj.toString();
+            String lower = CoreUtilities.toLowerCase(determination);
+            if (lower.startsWith("cancel_message:")) {
+                event.setCancelMessage(determination.substring("cancel_message:".length()));
+                return true;
+            }
+        }
+        return super.applyDetermination(path, determinationObj);
+    }
+
+    @EventHandler
+    public void onTownyPlayerCreatesTown(PreNewTownEvent event) {
+        this.event = event;
+        fire(event);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerCreatesTownScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerCreatesTownScriptEvent.java
@@ -73,9 +73,7 @@ public class PlayerCreatesTownScriptEvent extends BukkitScriptEvent implements L
             case "town_name":
                 return new ElementTag(event.getTownName());
             case "cuboid":
-                return new CuboidTag(
-                        TownTag.getCornerMin(event.getTownLocation().getWorld(), event.getTownWorldCoord().getX(), event.getTownWorldCoord().getZ()),
-                        TownTag.getCornerMax(event.getTownLocation().getWorld(), event.getTownWorldCoord().getX(), event.getTownWorldCoord().getZ()));
+                return TownTag.getCuboid(event.getTownLocation().getWorld(), event.getTownWorldCoord().getX(), event.getTownWorldCoord().getZ());
         }
         return super.getContext(name);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerCreatesTownScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/PlayerCreatesTownScriptEvent.java
@@ -18,8 +18,6 @@ public class PlayerCreatesTownScriptEvent extends BukkitScriptEvent implements L
     // @Events
     // towny player creates town
     //
-    // @Regex ^on towny player creates town$
-    //
     // @Location true
     //
     // @Cancellable true

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/TownCreatedScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/TownCreatedScriptEvent.java
@@ -1,0 +1,55 @@
+package com.denizenscript.depenizen.bukkit.events.towny;
+
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.depenizen.bukkit.objects.towny.TownTag;
+import com.palmergames.bukkit.towny.event.NewTownEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class TownCreatedScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // towny town created
+    //
+    // @Regex ^on towny town created$
+    //
+    // @Triggers after all checks are complete and a Towny town is fully created.
+    //
+    // @Context
+    // <context.town> Returns the town that was created.
+    //
+    // @Plugin Depenizen, Towny
+    //
+    // @Group Depenizen
+    //
+    // -->
+
+    public TownCreatedScriptEvent() {
+        instance = this;
+        registerCouldMatcher("towny town created");
+    }
+
+    public static TownCreatedScriptEvent instance;
+    public NewTownEvent event;
+
+    @Override
+    public String getName() {
+        return "TownyTownCreated";
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("town")) {
+            return new TownTag(event.getTown());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onTownyTownCreated(NewTownEvent event) {
+        this.event = event;
+        fire(event);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/TownCreatedScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/towny/TownCreatedScriptEvent.java
@@ -13,8 +13,6 @@ public class TownCreatedScriptEvent extends BukkitScriptEvent implements Listene
     // @Events
     // towny town created
     //
-    // @Regex ^on towny town created$
-    //
     // @Triggers after all checks are complete and a Towny town is fully created.
     //
     // @Context

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/griefprevention/GriefPreventionClaimTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/griefprevention/GriefPreventionClaimTag.java
@@ -1,15 +1,12 @@
 package com.denizenscript.depenizen.bukkit.objects.griefprevention;
 
+import com.denizenscript.denizen.objects.*;
 import com.denizenscript.denizencore.objects.*;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import me.ryanhamshire.GriefPrevention.Claim;
 import me.ryanhamshire.GriefPrevention.DataStore;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
-import com.denizenscript.denizen.objects.ChunkTag;
-import com.denizenscript.denizen.objects.CuboidTag;
-import com.denizenscript.denizen.objects.LocationTag;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.tags.Attribute;
@@ -236,10 +233,20 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // -->
         else if (attribute.startsWith("cuboid")) {
             LocationTag lower = new LocationTag(claim.getLesserBoundaryCorner());
-            lower.setY(0);
             LocationTag upper = new LocationTag(claim.getGreaterBoundaryCorner());
-            upper.setY(255);
+            upper.setY(upper.getWorld().getMaxHeight());
             return new CuboidTag(lower, upper).getObjectAttribute(attribute.fulfill(1));
+        }
+
+        // <--[tag]
+        // @attribute <GriefPreventionClaimTag.world>
+        // @returns WorldTag
+        // @Plugin Depenizen, GriefPrevention
+        // @description
+        // Returns the world this GriefPreventionClaim is in.
+        // -->
+        else if (attribute.startsWith("world")) {
+            return new WorldTag(claim.getLesserBoundaryCorner().getWorld());
         }
 
         // <--[tag]

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/griefprevention/GriefPreventionClaimTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/griefprevention/GriefPreventionClaimTag.java
@@ -1,9 +1,14 @@
 package com.denizenscript.depenizen.bukkit.objects.griefprevention;
 
 import com.denizenscript.denizen.objects.*;
+import com.denizenscript.denizencore.DenizenCore;
+import com.denizenscript.denizencore.flags.AbstractFlagTracker;
+import com.denizenscript.denizencore.flags.FlaggableObject;
+import com.denizenscript.denizencore.flags.RedirectionFlagTracker;
 import com.denizenscript.denizencore.objects.*;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import me.ryanhamshire.GriefPrevention.Claim;
 import me.ryanhamshire.GriefPrevention.DataStore;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
@@ -17,12 +22,13 @@ import org.bukkit.Chunk;
 import java.util.ArrayList;
 import java.util.UUID;
 
-public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
+public class GriefPreventionClaimTag implements ObjectTag, Adjustable, FlaggableObject {
 
     // <--[ObjectType]
     // @name GriefPreventionClaimTag
     // @prefix gpclaim
     // @base ElementTag
+    // @implements FlaggableObject
     // @format
     // The identity format for claims is <claim_id>
     // For example, 'gpclaim@1234'.
@@ -30,6 +36,9 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
     // @plugin Depenizen, GriefPrevention
     // @description
     // A GriefPreventionClaimTag represents a GriefPrevention claim.
+    //
+    // This object type is flaggable.
+    // Flags on this object type will be stored in the server saves file, under special sub-key "__depenizen_gp_claims_id"
     //
     // -->
 
@@ -98,6 +107,16 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         return identify();
     }
 
+    @Override
+    public AbstractFlagTracker getFlagTracker() {
+        return new RedirectionFlagTracker(DenizenCore.serverFlagMap, "__depenizen_gp_claims_id." + claim.getID());
+    }
+
+    @Override
+    public void reapplyTracker(AbstractFlagTracker tracker) {
+        // Nothing to do.
+    }
+
     public String simple() {
         return String.valueOf(claim.getID());
     }
@@ -107,11 +126,16 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         return identify();
     }
 
+    public static ObjectTagProcessor<GriefPreventionClaimTag> tagProcessor = new ObjectTagProcessor<>();
+
     @Override
     public ObjectTag getObjectAttribute(Attribute attribute) {
-        if (attribute == null) {
-            return null;
-        }
+        return tagProcessor.getObjectAttribute(this, attribute);
+    }
+
+    public static void registerTags() {
+
+        AbstractFlagTracker.registerFlagHandlers(tagProcessor);
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.id>
@@ -120,9 +144,9 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns the GriefPreventionClaim's ID.
         // -->
-        if (attribute.startsWith("id")) {
-            return new ElementTag(claim.getID()).getObjectAttribute(attribute.fulfill(1));
-        }
+        tagProcessor.registerTag(ElementTag.class, "id", (attribute, object) -> {
+            return new ElementTag(object.claim.getID());
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.managers>
@@ -131,13 +155,13 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns the GriefPreventionClaim's managers.
         // -->
-        if (attribute.startsWith("managers")) {
+        tagProcessor.registerTag(ListTag.class, "managers", (attribute, object) -> {
             ListTag managers = new ListTag();
-            for (String manager : claim.managers) {
+            for (String manager : object.claim.managers) {
                 managers.addObject(new PlayerTag(UUID.fromString(manager)));
             }
-            return managers.getObjectAttribute(attribute.fulfill(1));
-        }
+            return managers;
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.trusted>
@@ -146,15 +170,15 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns the GriefPreventionClaim's trusted.
         // -->
-        if (attribute.startsWith("trusted")) {
+        tagProcessor.registerTag(ListTag.class, "trusted", (attribute, object) -> {
             ListTag trusted = new ListTag();
             ArrayList<String> b = new ArrayList<>();
-            claim.getPermissions(b, new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+            object.claim.getPermissions(b, new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
             for (String trust : b) {
                 trusted.addObject(new PlayerTag(UUID.fromString(trust)));
             }
-            return trusted.getObjectAttribute(attribute.fulfill(1));
-        }
+            return trusted;
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.builders>
@@ -163,15 +187,15 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns the GriefPreventionClaim's builders.
         // -->
-        if (attribute.startsWith("builders")) {
+        tagProcessor.registerTag(ListTag.class, "builders", (attribute, object) -> {
             ListTag trusted = new ListTag();
             ArrayList<String> b = new ArrayList<>();
-            claim.getPermissions(b, new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+            object.claim.getPermissions(b, new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
             for (String trust : b) {
                 trusted.addObject(new PlayerTag(UUID.fromString(trust)));
             }
-            return trusted.getObjectAttribute(attribute.fulfill(1));
-        }
+            return trusted;
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.containers>
@@ -180,15 +204,15 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns the GriefPreventionClaim's containers.
         // -->
-        if (attribute.startsWith("containers")) {
+        tagProcessor.registerTag(ListTag.class, "containers", (attribute, object) -> {
             ListTag trusted = new ListTag();
             ArrayList<String> c = new ArrayList<>();
-            claim.getPermissions(new ArrayList<>(), c, new ArrayList<>(), new ArrayList<>());
+            object.claim.getPermissions(new ArrayList<>(), c, new ArrayList<>(), new ArrayList<>());
             for (String container : c) {
                 trusted.addObject(new PlayerTag(UUID.fromString(container)));
             }
-            return trusted.getObjectAttribute(attribute.fulfill(1));
-        }
+            return trusted;
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.accessors>
@@ -197,15 +221,15 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns the GriefPreventionClaim's accessors.
         // -->
-        if (attribute.startsWith("accessors")) {
+        tagProcessor.registerTag(ListTag.class, "accessors", (attribute, object) -> {
             ListTag trusted = new ListTag();
             ArrayList<String> a = new ArrayList<>();
-            claim.getPermissions(new ArrayList<>(), new ArrayList<>(), a, new ArrayList<>());
+            object.claim.getPermissions(new ArrayList<>(), new ArrayList<>(), a, new ArrayList<>());
             for (String access : a) {
                 trusted.addObject(new PlayerTag(UUID.fromString(access)));
             }
-            return trusted.getObjectAttribute(attribute.fulfill(1));
-        }
+            return trusted;
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.owner>
@@ -216,13 +240,12 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // Returns the GriefPreventionClaim's owner.
         // Can be "Admin" or a PlayerTag.
         // -->
-        else if (attribute.startsWith("owner")) {
-            if (claim.isAdminClaim()) {
-                return new ElementTag("Admin").getObjectAttribute(attribute.fulfill(1));
+        tagProcessor.registerTag(ObjectTag.class, "owner", (attribute, object) -> {
+            if (object.claim.isAdminClaim()) {
+                return new ElementTag("Admin");
             }
-            return new PlayerTag(claim.ownerID)
-                    .getObjectAttribute(attribute.fulfill(1));
-        }
+            return new PlayerTag(object.claim.ownerID);
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.cuboid>
@@ -231,12 +254,12 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns the GriefPreventionClaim's cuboid area.
         // -->
-        else if (attribute.startsWith("cuboid")) {
-            LocationTag lower = new LocationTag(claim.getLesserBoundaryCorner());
-            LocationTag upper = new LocationTag(claim.getGreaterBoundaryCorner());
+        tagProcessor.registerTag(CuboidTag.class, "cuboid", (attribute, object) -> {
+            LocationTag lower = new LocationTag(object.claim.getLesserBoundaryCorner());
+            LocationTag upper = new LocationTag(object.claim.getGreaterBoundaryCorner());
             upper.setY(upper.getWorld().getMaxHeight());
-            return new CuboidTag(lower, upper).getObjectAttribute(attribute.fulfill(1));
-        }
+            return new CuboidTag(lower, upper);
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.world>
@@ -245,9 +268,9 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns the world this GriefPreventionClaim is in.
         // -->
-        else if (attribute.startsWith("world")) {
-            return new WorldTag(claim.getLesserBoundaryCorner().getWorld());
-        }
+        tagProcessor.registerTag(WorldTag.class, "world", (attribute, object) -> {
+            return new WorldTag(object.claim.getLesserBoundaryCorner().getWorld());
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.is_adminclaim>
@@ -256,9 +279,9 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns whether GriefPreventionClaim is an Admin Claim.
         // -->
-        else if (attribute.startsWith("is_adminclaim") || attribute.startsWith("is_admin_claim")) {
-            return new ElementTag(claim.isAdminClaim()).getObjectAttribute(attribute.fulfill(1));
-        }
+        tagProcessor.registerTag(ElementTag.class, "is_adminclaim", (attribute, object) -> {
+            return new ElementTag(object.claim.isAdminClaim());
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.chunks>
@@ -267,13 +290,13 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns a list of all chunks in the GriefPreventionClaim.
         // -->
-        else if (attribute.startsWith("chunks")) {
+        tagProcessor.registerTag(ListTag.class, "chunks", (attribute, object) -> {
             ListTag chunks = new ListTag();
-            for (Chunk chunk : claim.getChunks()) {
+            for (Chunk chunk : object.claim.getChunks()) {
                 chunks.addObject(new ChunkTag(chunk));
             }
-            return chunks.getObjectAttribute(attribute.fulfill(1));
-        }
+            return chunks;
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.can_siege[<player>]>
@@ -282,13 +305,16 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns whether the GriefPreventionClaim can siege the player.
         // -->
-        else if (attribute.startsWith("can_siege") && attribute.hasParam()) {
+        tagProcessor.registerTag(ElementTag.class, "can_siege", (attribute, object) -> {
+            if (!attribute.hasParam()) {
+                return null;
+            }
             PlayerTag defender = attribute.paramAsType(PlayerTag.class);
             if (defender == null || defender.getPlayerEntity() == null) {
                 return null;
             }
-            return new ElementTag(claim.canSiege(defender.getPlayerEntity())).getObjectAttribute(attribute.fulfill(1));
-        }
+            return new ElementTag(object.claim.canSiege(defender.getPlayerEntity()));
+        });
 
         // <--[tag]
         // @attribute <GriefPreventionClaimTag.is_sieged>
@@ -297,11 +323,9 @@ public class GriefPreventionClaimTag implements ObjectTag, Adjustable {
         // @description
         // Returns whether the GriefPreventionClaim is currently under siege.
         // -->
-        else if (attribute.startsWith("is_sieged")) {
-            return new ElementTag(claim.siegeData != null).getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return new ElementTag(identify()).getObjectAttribute(attribute);
+        tagProcessor.registerTag(ElementTag.class, "is_sieged", (attribute, object) -> {
+            return new ElementTag(object.claim.siegeData != null);
+        });
     }
 
     @Override

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/towny/TownTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/towny/TownTag.java
@@ -106,12 +106,12 @@ public class TownTag implements ObjectTag, Adjustable, FlaggableObject {
         }
     }
 
-    public static LocationTag getCornerMin(World world, int townCoordX, int townCoordZ) {
-        return new LocationTag(world, townCoordX * Coord.getCellSize(), world.getMinHeight(), townCoordZ * Coord.getCellSize());
-    }
-
-    public static LocationTag getCornerMax(World world, int townCoordX, int townCoordZ) {
-        return new LocationTag(world, townCoordX * Coord.getCellSize() + Coord.getCellSize() - 1, world.getMaxHeight(), townCoordZ * Coord.getCellSize() + Coord.getCellSize() - 1);
+    public static CuboidTag getCuboid(World world, int townCoordX, int townCoordZ) {
+        int x = townCoordX * Coord.getCellSize();
+        int z = townCoordZ * Coord.getCellSize();
+        return new CuboidTag(
+                new LocationTag(world, x, world.getMinHeight(), z),
+                new LocationTag(world, x + Coord.getCellSize() - 1, world.getMaxHeight(), z + Coord.getCellSize() - 1));
     }
 
     /////////////////////
@@ -474,7 +474,7 @@ public class TownTag implements ObjectTag, Adjustable, FlaggableObject {
         // @description
         // Returns a list of chunks the town has claimed.
         // Note that this will not be accurate if the plot size has been changed in your Towny config.
-        // Generally, use <@link tag TownTag.claimed_cuboid> instead.
+        // Generally, use <@link tag TownTag.cuboids> instead.
         // -->
         tagProcessor.registerTag(ListTag.class, "plots", (attribute, object) -> {
             ListTag output = new ListTag();
@@ -485,16 +485,17 @@ public class TownTag implements ObjectTag, Adjustable, FlaggableObject {
         });
 
         // <--[tag]
-        // @attribute <TownTag.claimed_cuboid>
-        // @returns CuboidTag
+        // @attribute <TownTag.cuboids>
+        // @returns ListTag(CuboidTag)
         // @plugin Depenizen, Towny
         // @description
-        // Returns a cuboid of all plots claimed by the town.
+        // Returns a list of plot cuboids claimed by the town.
+        // Note that the cuboids may be in separate worlds if the town has outposts.
         // -->
-        tagProcessor.registerTag(CuboidTag.class, "claimed_cuboid", (attribute, object) -> {
-            CuboidTag output = new CuboidTag();
+        tagProcessor.registerTag(ListTag.class, "cuboids", (attribute, object) -> {
+            ListTag output = new ListTag();
             for (TownBlock block : object.town.getTownBlocks()) {
-                output.addPair(getCornerMin(object.town.getWorld(), block.getX(), block.getZ()), getCornerMax(object.town.getWorld(), block.getX(), block.getZ()));
+                output.addObject(getCuboid(object.town.getWorld(), block.getX(), block.getZ()));
             }
             return output;
         });

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/griefprevention/GriefPreventionWorldProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/griefprevention/GriefPreventionWorldProperties.java
@@ -1,0 +1,86 @@
+package com.denizenscript.depenizen.bukkit.properties.griefprevention;
+
+import com.denizenscript.denizen.objects.WorldTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.depenizen.bukkit.objects.griefprevention.GriefPreventionClaimTag;
+import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.tags.Attribute;
+
+public class GriefPreventionWorldProperties implements Property {
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "GriefPreventionWorld";
+    }
+
+    public static boolean describes(ObjectTag object) {
+        return object instanceof WorldTag;
+    }
+
+    public static GriefPreventionWorldProperties getFrom(ObjectTag object) {
+        if (!describes(object)) {
+            return null;
+        }
+        else {
+            return new GriefPreventionWorldProperties((WorldTag) object);
+        }
+    }
+
+    public static final String[] handledTags = new String[] {
+            "griefprevention"
+    };
+
+    public static final String[] handledMechs = new String[] {
+    }; // None
+
+    private GriefPreventionWorldProperties(WorldTag world) {
+        this.world = world;
+    }
+
+    WorldTag world;
+
+    @Override
+    public ObjectTag getObjectAttribute(Attribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+
+        if (attribute.startsWith("grief_prevention")
+                || attribute.startsWith("gp")
+                || attribute.startsWith("griefprevention")) {
+            attribute = attribute.fulfill(1);
+
+            // <--[tag]
+            // @attribute <WorldTag.griefprevention.claims>
+            // @returns ListTag(GriefPreventionClaimTag)
+            // @plugin Depenizen, GriefPrevention
+            // @description
+            // Returns a list of GriefPreventionClaim in this world.
+            // -->
+            if (attribute.startsWith("claims")) {
+                ListTag result = new ListTag();
+                for (Claim claim : GriefPrevention.instance.dataStore.getClaims()) {
+                    if (world.getWorld().equals(claim.getLesserBoundaryCorner().getWorld())) {
+                        result.addObject(new GriefPreventionClaimTag(claim));
+                    }
+                }
+                return result.getObjectAttribute(attribute.fulfill(1));
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/griefprevention/GriefPreventionWorldProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/griefprevention/GriefPreventionWorldProperties.java
@@ -4,11 +4,11 @@ import com.denizenscript.denizen.objects.WorldTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.depenizen.bukkit.objects.griefprevention.GriefPreventionClaimTag;
 import me.ryanhamshire.GriefPrevention.Claim;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.tags.Attribute;
 
 public class GriefPreventionWorldProperties implements Property {
 
@@ -35,10 +35,6 @@ public class GriefPreventionWorldProperties implements Property {
         }
     }
 
-    public static final String[] handledTags = new String[] {
-            "griefprevention"
-    };
-
     public static final String[] handledMechs = new String[] {
     }; // None
 
@@ -48,36 +44,23 @@ public class GriefPreventionWorldProperties implements Property {
 
     WorldTag world;
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
-        if (attribute == null) {
-            return null;
-        }
-
-        if (attribute.startsWith("grief_prevention")
-                || attribute.startsWith("gp")
-                || attribute.startsWith("griefprevention")) {
-            attribute = attribute.fulfill(1);
-
-            // <--[tag]
-            // @attribute <WorldTag.griefprevention.claims>
-            // @returns ListTag(GriefPreventionClaimTag)
-            // @plugin Depenizen, GriefPrevention
-            // @description
-            // Returns a list of GriefPreventionClaim in this world.
-            // -->
-            if (attribute.startsWith("claims")) {
-                ListTag result = new ListTag();
-                for (Claim claim : GriefPrevention.instance.dataStore.getClaims()) {
-                    if (world.getWorld().equals(claim.getLesserBoundaryCorner().getWorld())) {
-                        result.addObject(new GriefPreventionClaimTag(claim));
-                    }
+    public static void registerTags() {
+        // <--[tag]
+        // @attribute <WorldTag.griefprevention_claims>
+        // @returns ListTag(GriefPreventionClaimTag)
+        // @plugin Depenizen, GriefPrevention
+        // @description
+        // Returns a list of GriefPreventionClaim in this world.
+        // -->
+        PropertyParser.<GriefPreventionWorldProperties, ListTag>registerTag(ListTag.class, "griefprevention_claims", (attribute, property) -> {
+            ListTag result = new ListTag();
+            for (Claim claim : GriefPrevention.instance.dataStore.getClaims()) {
+                if (property.world.getWorld().equals(claim.getLesserBoundaryCorner().getWorld())) {
+                    result.addObject(new GriefPreventionClaimTag(claim));
                 }
-                return result.getObjectAttribute(attribute.fulfill(1));
             }
-        }
-
-        return null;
+            return result;
+        });
     }
 
     @Override

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/towny/TownyWorldProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/towny/TownyWorldProperties.java
@@ -3,10 +3,10 @@ package com.denizenscript.depenizen.bukkit.properties.towny;
 import com.denizenscript.denizen.objects.WorldTag;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.tags.Attribute;
 
 public class TownyWorldProperties implements Property {
 
@@ -37,10 +37,6 @@ public class TownyWorldProperties implements Property {
         }
     }
 
-    public static final String[] handledTags = new String[] {
-            "towny_enabled"
-    };
-
     public static final String[] handledMechs = new String[] {
     }; // None
 
@@ -50,8 +46,7 @@ public class TownyWorldProperties implements Property {
 
     public WorldTag world;
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <WorldTag.towny_enabled>
@@ -60,10 +55,8 @@ public class TownyWorldProperties implements Property {
         // @description
         // Returns whether this world has Towny enabled.
         // -->
-        if (attribute.startsWith("towny_enabled")) {
-            return new ElementTag(TownyAPI.getInstance().isTownyWorld(world.getWorld())).getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
+        PropertyParser.<TownyWorldProperties, ElementTag>registerTag(ElementTag.class, "towny_enabled", (attribute, property) -> {
+            return new ElementTag(TownyAPI.getInstance().isTownyWorld(property.world.getWorld()));
+        });
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/towny/TownyWorldProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/towny/TownyWorldProperties.java
@@ -1,0 +1,69 @@
+package com.denizenscript.depenizen.bukkit.properties.towny;
+
+import com.denizenscript.denizen.objects.WorldTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.tags.Attribute;
+
+public class TownyWorldProperties implements Property {
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "TownyWorld";
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+    }
+
+    public static boolean describes(ObjectTag object) {
+        return object instanceof WorldTag;
+    }
+
+    public static TownyWorldProperties getFrom(ObjectTag object) {
+        if (!describes(object)) {
+            return null;
+        }
+        else {
+            return new TownyWorldProperties((WorldTag) object);
+        }
+    }
+
+    public static final String[] handledTags = new String[] {
+            "towny_enabled"
+    };
+
+    public static final String[] handledMechs = new String[] {
+    }; // None
+
+    private TownyWorldProperties(WorldTag world) {
+        this.world = world;
+    }
+
+    public WorldTag world;
+
+    @Override
+    public ObjectTag getObjectAttribute(Attribute attribute) {
+
+        // <--[tag]
+        // @attribute <WorldTag.towny_enabled>
+        // @returns ElementTag(Boolean)
+        // @plugin Depenizen, Towny
+        // @description
+        // Returns whether this world has Towny enabled.
+        // -->
+        if (attribute.startsWith("towny_enabled")) {
+            return new ElementTag(TownyAPI.getInstance().isTownyWorld(world.getWorld())).getObjectAttribute(attribute.fulfill(1));
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
tested these changes to the best of my ability. i would like these features so i can easily check whether a towny land claim will intersect with any existing griefprevention claims

## New features:
`on towny player claims plot` -- when a player tries to claim a new towny plot/outpost
`on towny player creates town` -- when a player tries to make a new towny town
`on towny town created` -- after a town is actually created. plugin does some extra logic between this and the last event.

`<GriefPreventionClaimTag.world>` -- a convenience tag for grabbing the world a claim is in
`<TownTag.cuboids>` -- returns a list of cuboids a town has claimed. can contain cuboids from other worlds because of outposts.
`<WorldTag.griefprevention.claims>` -- returns a list of claims in this world
`<WorldTag.towny_enabled>` -- returns whether towny is enabled in the world

## Fixes:
`<GriefPreventionClaimTag.cuboid>` -- updated to be the actual cuboid protected by a claim
`<TownTag.plots>` -- docs were incorrect, and the tag breaks if you've touched plot size in the towny config. instead of changing the return type to a list of cuboids, added a cuboids tag for backwards compat