### PR TITLE
Fix cross-world town cuboids

### DIFF
--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/towny/TownTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/towny/TownTag.java
@@ -495,7 +495,7 @@ public class TownTag implements ObjectTag, Adjustable, FlaggableObject {
         tagProcessor.registerTag(ListTag.class, "cuboids", (attribute, object) -> {
             ListTag output = new ListTag();
             for (TownBlock block : object.town.getTownBlocks()) {
-                output.addObject(getCuboid(object.town.getWorld(), block.getX(), block.getZ()));
+                output.addObject(getCuboid(block.getWorldCoord().getBukkitWorld(), block.getX(), block.getZ()));
             }
             return output;
         });


### PR DESCRIPTION
This was a small oversight in the last PR. If a town is cross-world, the cuboids are using the main town's world instead of the world they're actually in