### PR TITLE
AriKeysPlugin Support

### DIFF
--- a/Docs/BukkitPlugins.md
+++ b/Docs/BukkitPlugins.md
@@ -2,6 +2,7 @@
 Supported Plugins: (And the sources we acquired Jar files from.)
 
 - AreaShop (https://www.spigotmc.org/resources/areashop.2991/)
+- AriKeys (https://www.spigotmc.org/resources/arikeysplugin-custom-keybinds.105968/)
 - ASkyBlock (https://www.spigotmc.org/resources/a-skyblock.1220/)
 - BetonQuest (https://www.spigotmc.org/resources/betonquest.2117/)
 - BigDoors (https://www.spigotmc.org/resources/big-doors.58669)

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,13 @@
             <systemPath>${basedir}/lib/AreaShop.jar</systemPath>
         </dependency>
         <dependency>
+            <groupId>eu.asangarin</groupId>
+            <artifactId>arikeys</artifactId>
+            <version>2.1</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/lib/arikeys.jar</systemPath>
+        </dependency>
+        <dependency>
             <groupId>com.wasteofplastic</groupId>
             <artifactId>askyblock</artifactId>
             <version>2.9.8.1</version>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/Depenizen.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/Depenizen.java
@@ -97,6 +97,7 @@ public class Depenizen extends JavaPlugin {
     public void registerCoreBridges() {
         // Yes it needs to be `new MyBridge()` not `MyBridge::new` - this is due to an error in the Java runtime.
         registerBridge("AreaShop", () -> new AreaShopBridge());
+        registerBridge("AriKeys", () -> new AriKeysBridge());
         registerBridge("ASkyBlock", () -> new ASkyBlockBridge());
         registerBridge("BetonQuest", () -> new BetonQuestBridge());
         registerBridge("BigDoors", () -> new BigDoorsBridge());

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/AriKeysBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/AriKeysBridge.java
@@ -1,0 +1,16 @@
+package com.denizenscript.depenizen.bukkit.bridges;
+
+import com.denizenscript.denizencore.events.ScriptEvent;
+import com.denizenscript.depenizen.bukkit.Bridge;
+import com.denizenscript.depenizen.bukkit.events.arikeys.AriKeysKeyPressScriptEvent;
+import com.denizenscript.depenizen.bukkit.events.arikeys.AriKeysKeyReleaseScriptEvent;
+
+
+public class AriKeysBridge extends Bridge {
+
+    @Override
+    public void init() {
+        ScriptEvent.registerScriptEvent(AriKeysKeyReleaseScriptEvent.class);
+        ScriptEvent.registerScriptEvent(AriKeysKeyPressScriptEvent.class);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/arikeys/AriKeysKeyPressScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/arikeys/AriKeysKeyPressScriptEvent.java
@@ -1,48 +1,43 @@
-package com.denizenscript.depenizen.bukkit.events.mythickeys;
+package com.denizenscript.depenizen.bukkit.events.arikeys;
 
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
-import com.denizenscript.denizencore.utilities.debugging.Warning;
-import eu.asangarin.mythickeys.api.MythicKeyReleaseEvent;
-import org.bukkit.Bukkit;
+import eu.asangarin.arikeys.api.AriKeyPressEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
-public class MythicKeysKeyReleaseScriptEvent extends BukkitScriptEvent implements Listener {
+public class AriKeysKeyPressScriptEvent extends BukkitScriptEvent implements Listener {
 
     // <--[event]
     // @Events
-    // mythickeys key released
+    // arikeys key pressed
     //
     // @Location true
     //
     // @Switch id:<id> to only process the event if the key ID matches the given text matcher.
     //
-    // @Triggers When a key stops being pressed by a client running MythicKeys, if that key is in the MythicKeys config.
+    // @Triggers When a key is pressed by a client running AriKeys, if that key is in the AriKeys config.
     //
     // @Context
-    // <context.id> Returns the ID of the key that was released according to the MythicKeys config, as a namespaced key.
+    // <context.id> Returns the ID of the key that was pressed according to the AriKeys config, as a namespaced key.
     //
     // @Player Always.
     //
-    // @Plugin Depenizen, MythicKeys
+    // @Plugin Depenizen, AriKeys
     //
     // @Group Depenizen
     //
-    // @Warning For 1.19+ servers use AriKeysPlugin.
-    //
     // -->
 
-    public MythicKeysKeyReleaseScriptEvent() {
-        registerCouldMatcher("mythickeys key released");
+    public AriKeysKeyPressScriptEvent() {
+        registerCouldMatcher("arikeys key pressed");
         registerSwitches("id");
     }
 
-    public MythicKeyReleaseEvent event;
-    public Warning outdatedMythicKeys = new Warning("mythicKeysOutdated", "MythicKeys is outdated. Use the plugin 'AriKeysPlugin' for 1.19+ servers.");
+    public AriKeyPressEvent event;
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -51,9 +46,6 @@ public class MythicKeysKeyReleaseScriptEvent extends BukkitScriptEvent implement
         }
         if (!runInCheck(path, event.getPlayer().getLocation())) {
             return false;
-        }
-        if (Bukkit.getBukkitVersion().substring(0, 4).equals("1.19")) {
-            outdatedMythicKeys.warn();
         }
         return super.matches(path);
     }
@@ -72,7 +64,7 @@ public class MythicKeysKeyReleaseScriptEvent extends BukkitScriptEvent implement
     }
 
     @EventHandler
-    public void onKeyRelease(MythicKeyReleaseEvent event) {
+    public void onKeyPress(AriKeyPressEvent event) {
         this.event = event;
         fire(event);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/arikeys/AriKeysKeyReleaseScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/arikeys/AriKeysKeyReleaseScriptEvent.java
@@ -1,48 +1,43 @@
-package com.denizenscript.depenizen.bukkit.events.mythickeys;
+package com.denizenscript.depenizen.bukkit.events.arikeys;
 
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
-import com.denizenscript.denizencore.utilities.debugging.Warning;
-import eu.asangarin.mythickeys.api.MythicKeyReleaseEvent;
-import org.bukkit.Bukkit;
+import eu.asangarin.arikeys.api.AriKeyReleaseEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
-public class MythicKeysKeyReleaseScriptEvent extends BukkitScriptEvent implements Listener {
+public class AriKeysKeyReleaseScriptEvent extends BukkitScriptEvent implements Listener {
 
     // <--[event]
     // @Events
-    // mythickeys key released
+    // arikeys key released
     //
     // @Location true
     //
     // @Switch id:<id> to only process the event if the key ID matches the given text matcher.
     //
-    // @Triggers When a key stops being pressed by a client running MythicKeys, if that key is in the MythicKeys config.
+    // @Triggers When a key stops being pressed by a client running AriKeys, if that key is in the AriKeys config.
     //
     // @Context
-    // <context.id> Returns the ID of the key that was released according to the MythicKeys config, as a namespaced key.
+    // <context.id> Returns the ID of the key that was released according to the AriKeys config, as a namespaced key.
     //
     // @Player Always.
     //
-    // @Plugin Depenizen, MythicKeys
+    // @Plugin Depenizen, AriKeys
     //
     // @Group Depenizen
     //
-    // @Warning For 1.19+ servers use AriKeysPlugin.
-    //
     // -->
 
-    public MythicKeysKeyReleaseScriptEvent() {
-        registerCouldMatcher("mythickeys key released");
+    public AriKeysKeyReleaseScriptEvent() {
+        registerCouldMatcher("arikeys key released");
         registerSwitches("id");
     }
 
-    public MythicKeyReleaseEvent event;
-    public Warning outdatedMythicKeys = new Warning("mythicKeysOutdated", "MythicKeys is outdated. Use the plugin 'AriKeysPlugin' for 1.19+ servers.");
+    public AriKeyReleaseEvent event;
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -51,9 +46,6 @@ public class MythicKeysKeyReleaseScriptEvent extends BukkitScriptEvent implement
         }
         if (!runInCheck(path, event.getPlayer().getLocation())) {
             return false;
-        }
-        if (Bukkit.getBukkitVersion().substring(0, 4).equals("1.19")) {
-            outdatedMythicKeys.warn();
         }
         return super.matches(path);
     }
@@ -72,7 +64,7 @@ public class MythicKeysKeyReleaseScriptEvent extends BukkitScriptEvent implement
     }
 
     @EventHandler
-    public void onKeyRelease(MythicKeyReleaseEvent event) {
+    public void onKeyRelease(AriKeyReleaseEvent event) {
         this.event = event;
         fire(event);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/mythickeys/MythicKeysKeyPressScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/mythickeys/MythicKeysKeyPressScriptEvent.java
@@ -5,7 +5,10 @@ import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.denizencore.utilities.debugging.SlowWarning;
+import com.denizenscript.denizencore.utilities.debugging.Warning;
 import eu.asangarin.mythickeys.api.MythicKeyPressEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -30,6 +33,8 @@ public class MythicKeysKeyPressScriptEvent extends BukkitScriptEvent implements 
     //
     // @Group Depenizen
     //
+    // @Warning For 1.19+ servers use AriKeysPlugin.
+    //
     // -->
 
     public MythicKeysKeyPressScriptEvent() {
@@ -38,6 +43,7 @@ public class MythicKeysKeyPressScriptEvent extends BukkitScriptEvent implements 
     }
 
     public MythicKeyPressEvent event;
+    public Warning outdatedMythicKeys = new Warning("mythicKeysOutdated", "MythicKeys is outdated. Use the plugin 'AriKeysPlugin' for 1.19+ servers.");
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -46,6 +52,9 @@ public class MythicKeysKeyPressScriptEvent extends BukkitScriptEvent implements 
         }
         if (!runInCheck(path, event.getPlayer().getLocation())) {
             return false;
+        }
+        if (Bukkit.getBukkitVersion().substring(0, 4).equals("1.19")) {
+            outdatedMythicKeys.warn();
         }
         return super.matches(path);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/mythickeys/MythicKeysKeyPressScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/mythickeys/MythicKeysKeyPressScriptEvent.java
@@ -1,6 +1,8 @@
 package com.denizenscript.depenizen.bukkit.events.mythickeys;
 
 import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -53,7 +55,7 @@ public class MythicKeysKeyPressScriptEvent extends BukkitScriptEvent implements 
         if (!runInCheck(path, event.getPlayer().getLocation())) {
             return false;
         }
-        if (Bukkit.getBukkitVersion().substring(0, 4).equals("1.19")) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
             outdatedMythicKeys.warn();
         }
         return super.matches(path);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/mythickeys/MythicKeysKeyReleaseScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/mythickeys/MythicKeysKeyReleaseScriptEvent.java
@@ -1,6 +1,8 @@
 package com.denizenscript.depenizen.bukkit.events.mythickeys;
 
 import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -52,7 +54,7 @@ public class MythicKeysKeyReleaseScriptEvent extends BukkitScriptEvent implement
         if (!runInCheck(path, event.getPlayer().getLocation())) {
             return false;
         }
-        if (Bukkit.getBukkitVersion().substring(0, 4).equals("1.19")) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
             outdatedMythicKeys.warn();
         }
         return super.matches(path);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,6 +8,7 @@ api-version: '1.13'
 
 softdepend:
     - AreaShop
+    - AriKeys
     - ASkyBlock
     - BetonQuest
     - BigDoors


### PR DESCRIPTION
Adds Support for AriKeysPlugin. Provides the same functionality as MythicKeys does. 

Added a deprecation warning when using MythicKeys on 1.19 servers and warning in the meta, because AriKeys only supports 1.19+ servers.