### PR TITLE
Residence bridge update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <dependency>
             <groupId>com.bekvon.bukkit</groupId>
             <artifactId>residence</artifactId>
-            <version>4.5.13.4</version>
+            <version>5.1.0.0</version>
             <scope>system</scope>
             <systemPath>${basedir}/lib/Residence.jar</systemPath>
         </dependency>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ResidenceBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ResidenceBridge.java
@@ -12,12 +12,14 @@ public class ResidenceBridge extends Bridge {
 
     @Override
     public void init() {
+
         // <--[tag]
         // @attribute <residence[<name>]>
         // @returns ResidenceTag
         // @plugin Depenizen, Residence
         // @description
         // Returns a residence object constructed from the input value.
+        // Refer to <@link objecttype ResidenceTag>.
         // -->
         ObjectFetcher.registerWithObjectFetcher(ResidenceTag.class, ResidenceTag.tagProcessor).generateBaseTag();
         ResidencePlayerExtensions.register();

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ResidenceBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ResidenceBridge.java
@@ -1,10 +1,10 @@
 package com.denizenscript.depenizen.bukkit.bridges;
 
-import com.denizenscript.depenizen.bukkit.events.residence.PlayerExitsResidenceScriptEvent;
+import com.denizenscript.denizencore.tags.TagManager;
+import com.denizenscript.depenizen.bukkit.events.residence.*;
 import com.denizenscript.depenizen.bukkit.properties.residence.ResidenceLocationProperties;
 import com.denizenscript.depenizen.bukkit.properties.residence.ResidencePlayerProperties;
 import com.denizenscript.depenizen.bukkit.Bridge;
-import com.denizenscript.depenizen.bukkit.events.residence.PlayerEntersResidenceScriptEvent;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.PlayerTag;
@@ -16,10 +16,28 @@ public class ResidenceBridge extends Bridge {
 
     @Override
     public void init() {
-        ObjectFetcher.registerWithObjectFetcher(ResidenceTag.class);
+        ObjectFetcher.registerWithObjectFetcher(ResidenceTag.class, ResidenceTag.tagProcessor);
         PropertyParser.registerProperty(ResidencePlayerProperties.class, PlayerTag.class);
         PropertyParser.registerProperty(ResidenceLocationProperties.class, LocationTag.class);
         ScriptEvent.registerScriptEvent(PlayerEntersResidenceScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerExitsResidenceScriptEvent.class);
+        ScriptEvent.registerScriptEvent(PlayerCreatesResidenceScriptEvent.class);
+        ScriptEvent.registerScriptEvent(ResidenceGetsDeletedScriptEvent.class);
+        ScriptEvent.registerScriptEvent(ResidenceRaidStartsScriptEvent.class);
+        ScriptEvent.registerScriptEvent(ResidenceRaidEndsScriptEvent.class);
+
+        // <--[tag]
+        // @attribute <residence[<name>]>
+        // @returns ResidenceTag
+        // @plugin Depenizen, Residence
+        // @description
+        // Returns the ResidenceTag of given residence name.
+        // -->
+        TagManager.registerTagHandler(ResidenceTag.class, "residence", attribute -> {
+            if (attribute.hasParam()) {
+                return ResidenceTag.valueOf(attribute.getParam(), attribute.context);
+            }
+            return null;
+        });
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ResidenceBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ResidenceBridge.java
@@ -6,19 +6,16 @@ import com.denizenscript.depenizen.bukkit.properties.residence.ResidenceLocation
 import com.denizenscript.depenizen.bukkit.properties.residence.ResidencePlayerProperties;
 import com.denizenscript.depenizen.bukkit.Bridge;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
-import com.denizenscript.denizen.objects.LocationTag;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.objects.ObjectFetcher;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
 
 public class ResidenceBridge extends Bridge {
 
     @Override
     public void init() {
-        ObjectFetcher.registerWithObjectFetcher(ResidenceTag.class, ResidenceTag.tagProcessor);
-        PropertyParser.registerProperty(ResidencePlayerProperties.class, PlayerTag.class);
-        PropertyParser.registerProperty(ResidenceLocationProperties.class, LocationTag.class);
+        ObjectFetcher.registerWithObjectFetcher(ResidenceTag.class, ResidenceTag.tagProcessor).generateBaseTag();
+        ResidencePlayerProperties.register();
+        ResidenceLocationProperties.register();
         ScriptEvent.registerScriptEvent(PlayerEntersResidenceScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerExitsResidenceScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerCreatesResidenceScriptEvent.class);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ResidenceBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ResidenceBridge.java
@@ -22,7 +22,7 @@ public class ResidenceBridge extends Bridge {
         ScriptEvent.registerScriptEvent(PlayerEntersResidenceScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerExitsResidenceScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerCreatesResidenceScriptEvent.class);
-        ScriptEvent.registerScriptEvent(ResidenceGetsDeletedScriptEvent.class);
+        ScriptEvent.registerScriptEvent(ResidenceDeletedScriptEvent.class);
         ScriptEvent.registerScriptEvent(ResidenceRaidStartsScriptEvent.class);
         ScriptEvent.registerScriptEvent(ResidenceRaidEndsScriptEvent.class);
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ResidenceBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ResidenceBridge.java
@@ -1,9 +1,8 @@
 package com.denizenscript.depenizen.bukkit.bridges;
 
-import com.denizenscript.denizencore.tags.TagManager;
 import com.denizenscript.depenizen.bukkit.events.residence.*;
-import com.denizenscript.depenizen.bukkit.properties.residence.ResidenceLocationProperties;
-import com.denizenscript.depenizen.bukkit.properties.residence.ResidencePlayerProperties;
+import com.denizenscript.depenizen.bukkit.properties.residence.ResidenceLocationExtensions;
+import com.denizenscript.depenizen.bukkit.properties.residence.ResidencePlayerExtensions;
 import com.denizenscript.depenizen.bukkit.Bridge;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import com.denizenscript.denizencore.events.ScriptEvent;
@@ -13,28 +12,21 @@ public class ResidenceBridge extends Bridge {
 
     @Override
     public void init() {
+        // <--[tag]
+        // @attribute <residence[<name>]>
+        // @returns ResidenceTag
+        // @plugin Depenizen, Residence
+        // @description
+        // Returns a residence object constructed from the input value.
+        // -->
         ObjectFetcher.registerWithObjectFetcher(ResidenceTag.class, ResidenceTag.tagProcessor).generateBaseTag();
-        ResidencePlayerProperties.register();
-        ResidenceLocationProperties.register();
+        ResidencePlayerExtensions.register();
+        ResidenceLocationExtensions.register();
         ScriptEvent.registerScriptEvent(PlayerEntersResidenceScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerExitsResidenceScriptEvent.class);
         ScriptEvent.registerScriptEvent(PlayerCreatesResidenceScriptEvent.class);
         ScriptEvent.registerScriptEvent(ResidenceDeletedScriptEvent.class);
         ScriptEvent.registerScriptEvent(ResidenceRaidStartsScriptEvent.class);
         ScriptEvent.registerScriptEvent(ResidenceRaidEndsScriptEvent.class);
-
-        // <--[tag]
-        // @attribute <residence[<name>]>
-        // @returns ResidenceTag
-        // @plugin Depenizen, Residence
-        // @description
-        // Returns the ResidenceTag of given residence name.
-        // -->
-        TagManager.registerTagHandler(ResidenceTag.class, "residence", attribute -> {
-            if (attribute.hasParam()) {
-                return ResidenceTag.valueOf(attribute.getParam(), attribute.context);
-            }
-            return null;
-        });
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerCreatesResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerCreatesResidenceScriptEvent.java
@@ -14,7 +14,6 @@ public class PlayerCreatesResidenceScriptEvent extends BukkitScriptEvent impleme
     // <--[event]
     // @Events
     // residence player creates residence
-    // residence player create residence
     //
     // @Triggers when a player creates a Residence.
     //
@@ -30,7 +29,7 @@ public class PlayerCreatesResidenceScriptEvent extends BukkitScriptEvent impleme
     // -->
 
     public PlayerCreatesResidenceScriptEvent() {
-        registerCouldMatcher("residence player creates residence"); registerCouldMatcher("residence player create residence");
+        registerCouldMatcher("residence player creates residence");
     }
 
     public ResidenceCreationEvent event;

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerCreatesResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerCreatesResidenceScriptEvent.java
@@ -1,0 +1,59 @@
+package com.denizenscript.depenizen.bukkit.events.residence;
+
+import com.bekvon.bukkit.residence.event.ResidenceCreationEvent;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class PlayerCreatesResidenceScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // residence player creates residence
+    // residence player create residence
+    //
+    // @Triggers when a player creates a Residence.
+    //
+    // @Context
+    // <context.residence> Returns the ResidenceTag of created residence.
+    //
+    // @Plugin Depenizen, Residence
+    //
+    // @Player Always.
+    //
+    // @Group Depenizen
+    //
+    // -->
+
+    public PlayerCreatesResidenceScriptEvent() {
+        registerCouldMatcher("residence player creates residence"); registerCouldMatcher("residence player create residence");
+    }
+
+    public ResidenceCreationEvent event;
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getPlayer());
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("residence")) {
+            return new ResidenceTag(event.getResidence());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onResidencePlayerCreatesResidence(ResidenceCreationEvent event) {
+        if (event.getResidence() == null) {
+            return;
+        }
+        this.event = event;
+        fire(event);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerCreatesResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerCreatesResidenceScriptEvent.java
@@ -42,8 +42,8 @@ public class PlayerCreatesResidenceScriptEvent extends BukkitScriptEvent impleme
 
     @Override
     public ObjectTag getContext(String name) {
-        if (name.equals("residence")) {
-            return new ResidenceTag(event.getResidence());
+        switch (name) {
+            case "residence": return new ResidenceTag(event.getResidence());
         }
         return super.getContext(name);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerCreatesResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerCreatesResidenceScriptEvent.java
@@ -15,10 +15,12 @@ public class PlayerCreatesResidenceScriptEvent extends BukkitScriptEvent impleme
     // @Events
     // residence player creates residence
     //
+    // @Cancellable true
+    //
     // @Triggers when a player creates a Residence.
     //
     // @Context
-    // <context.residence> Returns the ResidenceTag of created residence.
+    // <context.residence> Returns the created ResidenceTag.
     //
     // @Plugin Depenizen, Residence
     //
@@ -49,9 +51,6 @@ public class PlayerCreatesResidenceScriptEvent extends BukkitScriptEvent impleme
 
     @EventHandler
     public void onResidencePlayerCreatesResidence(ResidenceCreationEvent event) {
-        if (event.getResidence() == null) {
-            return;
-        }
         this.event = event;
         fire(event);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerEntersResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerEntersResidenceScriptEvent.java
@@ -44,7 +44,9 @@ public class PlayerEntersResidenceScriptEvent extends BukkitScriptEvent implemen
     }
 
     @Override
-    public ScriptEntryData getScriptEntryData() { return new BukkitScriptEntryData(event.getPlayer()); }
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getPlayer());
+    }
 
     @Override
     public ObjectTag getContext(String name) {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerEntersResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerEntersResidenceScriptEvent.java
@@ -52,8 +52,8 @@ public class PlayerEntersResidenceScriptEvent extends BukkitScriptEvent implemen
 
     @Override
     public ObjectTag getContext(String name) {
-        if (name.equals("residence")) {
-            return residence;
+        switch (name) {
+            case "residence": return residence;
         }
         return super.getContext(name);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerEntersResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerEntersResidenceScriptEvent.java
@@ -14,7 +14,6 @@ public class PlayerEntersResidenceScriptEvent extends BukkitScriptEvent implemen
     // <--[event]
     // @Events
     // residence player enters <'residence'>
-    // residence player enter <'residence'>
     //
     // @Triggers when a player enters a Residence.
     //
@@ -30,7 +29,7 @@ public class PlayerEntersResidenceScriptEvent extends BukkitScriptEvent implemen
     // -->
 
     public PlayerEntersResidenceScriptEvent() {
-        registerCouldMatcher("residence player enters <'residence'>"); registerCouldMatcher("residence player enter <'residence'>");
+        registerCouldMatcher("residence player enters <'residence'>");
     }
 
     public ResidenceChangedEvent event;

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerEntersResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerEntersResidenceScriptEvent.java
@@ -37,17 +37,14 @@ public class PlayerEntersResidenceScriptEvent extends BukkitScriptEvent implemen
 
     @Override
     public boolean matches(ScriptPath path) {
-        String name = path.eventArgLowerAt(3);
-        if (!name.equals("residence") && !residence.equals(ResidenceTag.valueOf(name))) {
+        if (!path.tryArgObject(3, residence)) {
             return false;
         }
         return super.matches(path);
     }
 
     @Override
-    public ScriptEntryData getScriptEntryData() {
-        return new BukkitScriptEntryData(event.getPlayer());
-    }
+    public ScriptEntryData getScriptEntryData() { return new BukkitScriptEntryData(event.getPlayer()); }
 
     @Override
     public ObjectTag getContext(String name) {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerEntersResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerEntersResidenceScriptEvent.java
@@ -14,6 +14,7 @@ public class PlayerEntersResidenceScriptEvent extends BukkitScriptEvent implemen
     // <--[event]
     // @Events
     // residence player enters <'residence'>
+    // residence player enter <'residence'>
     //
     // @Triggers when a player enters a Residence.
     //
@@ -29,7 +30,7 @@ public class PlayerEntersResidenceScriptEvent extends BukkitScriptEvent implemen
     // -->
 
     public PlayerEntersResidenceScriptEvent() {
-        registerCouldMatcher("residence player enters <'residence'>");
+        registerCouldMatcher("residence player enters <'residence'>"); registerCouldMatcher("residence player enter <'residence'>");
     }
 
     public ResidenceChangedEvent event;

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerExitsResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerExitsResidenceScriptEvent.java
@@ -14,7 +14,6 @@ public class PlayerExitsResidenceScriptEvent extends BukkitScriptEvent implement
     // <--[event]
     // @Events
     // residence player exits <'residence'>
-    // residence player exit <'residence'>
     //
     // @Triggers when a player exits a Residence.
     //
@@ -30,7 +29,7 @@ public class PlayerExitsResidenceScriptEvent extends BukkitScriptEvent implement
     // -->
 
     public PlayerExitsResidenceScriptEvent() {
-        registerCouldMatcher("residence player exits <'residence'>"); registerCouldMatcher("residence player exit <'residence'>");
+        registerCouldMatcher("residence player exits <'residence'>");
     }
 
     public ResidenceChangedEvent event;

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerExitsResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerExitsResidenceScriptEvent.java
@@ -14,6 +14,7 @@ public class PlayerExitsResidenceScriptEvent extends BukkitScriptEvent implement
     // <--[event]
     // @Events
     // residence player exits <'residence'>
+    // residence player exit <'residence'>
     //
     // @Triggers when a player exits a Residence.
     //
@@ -29,7 +30,7 @@ public class PlayerExitsResidenceScriptEvent extends BukkitScriptEvent implement
     // -->
 
     public PlayerExitsResidenceScriptEvent() {
-        registerCouldMatcher("residence player exits <'residence'>");
+        registerCouldMatcher("residence player exits <'residence'>"); registerCouldMatcher("residence player exit <'residence'>");
     }
 
     public ResidenceChangedEvent event;

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerExitsResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerExitsResidenceScriptEvent.java
@@ -37,8 +37,7 @@ public class PlayerExitsResidenceScriptEvent extends BukkitScriptEvent implement
 
     @Override
     public boolean matches(ScriptPath path) {
-        String name = path.eventArgLowerAt(3);
-        if (!name.equals("residence") && !residence.equals(ResidenceTag.valueOf(name))) {
+        if (!path.tryArgObject(3, residence)) {
             return false;
         }
         return super.matches(path);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerExitsResidenceScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/PlayerExitsResidenceScriptEvent.java
@@ -52,8 +52,8 @@ public class PlayerExitsResidenceScriptEvent extends BukkitScriptEvent implement
 
     @Override
     public ObjectTag getContext(String name) {
-        if (name.equals("residence")) {
-            return residence;
+        switch (name) {
+            case "residence": return residence;
         }
         return super.getContext(name);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceDeletedScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceDeletedScriptEvent.java
@@ -10,19 +10,19 @@ import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
-public class ResidenceGetsDeletedScriptEvent extends BukkitScriptEvent implements Listener {
+public class ResidenceDeletedScriptEvent extends BukkitScriptEvent implements Listener {
 
     // <--[event]
     // @Events
-    // residence gets deleted
+    // residence deleted
     //
-    // @Switch cause:<cause> to only process the event if the cause matches specified cause.
+    // @Switch cause:<cause> to only process the event if the cause of deletion matches.
     //
     // @Triggers when a Residence gets deleted.
     //
     // @Context
-    // <context.cause> Returns the cause of deletion. ( Available causes: PLAYER_DELETE, OTHER, LEASE_EXPIRE )
-    // <context.residence> Returns the ResidenceTag of deleted residence.
+    // <context.cause> Returns the cause of deletion. Can be: PLAYER_DELETE, OTHER or LEASE_EXPIRE
+    // <context.residence> Returns the ResidenceTag of the deleted residence.
     //
     // @Plugin Depenizen, Residence
     //
@@ -32,17 +32,16 @@ public class ResidenceGetsDeletedScriptEvent extends BukkitScriptEvent implement
     //
     // -->
 
-    public ResidenceGetsDeletedScriptEvent() {
-        registerCouldMatcher("residence gets deleted");
+    public ResidenceDeletedScriptEvent() {
+        registerCouldMatcher("residence deleted");
         registerSwitches("cause");
     }
 
     public ResidenceDeleteEvent event;
-    public String cause;
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!runGenericSwitchCheck(path, "cause", cause)) {
+        if (!runGenericSwitchCheck(path, "cause", event.getCause().name())) {
             return false;
         }
         return super.matches(path);
@@ -56,15 +55,14 @@ public class ResidenceGetsDeletedScriptEvent extends BukkitScriptEvent implement
     @Override
     public ObjectTag getContext(String name) {
         switch (name) {
-            case "cause": return new ElementTag(cause);
+            case "cause": return new ElementTag(event.getCause().name());
             case "residence": return new ResidenceTag(event.getResidence());
         }
         return super.getContext(name);
     }
 
     @EventHandler
-    public void onResidenceGetsDeleted(ResidenceDeleteEvent event) {
-        cause = event.getCause().name();
+    public void onResidenceDeleted(ResidenceDeleteEvent event) {
         this.event = event;
         fire(event);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceDeletedScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceDeletedScriptEvent.java
@@ -38,10 +38,11 @@ public class ResidenceDeletedScriptEvent extends BukkitScriptEvent implements Li
     }
 
     public ResidenceDeleteEvent event;
+    public ElementTag cause;
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!runGenericSwitchCheck(path, "cause", event.getCause().name())) {
+        if (!path.tryObjectSwitch("cause", cause)) {
             return false;
         }
         return super.matches(path);
@@ -55,7 +56,7 @@ public class ResidenceDeletedScriptEvent extends BukkitScriptEvent implements Li
     @Override
     public ObjectTag getContext(String name) {
         switch (name) {
-            case "cause": return new ElementTag(event.getCause().name());
+            case "cause": return cause;
             case "residence": return new ResidenceTag(event.getResidence());
         }
         return super.getContext(name);
@@ -64,6 +65,7 @@ public class ResidenceDeletedScriptEvent extends BukkitScriptEvent implements Li
     @EventHandler
     public void onResidenceDeleted(ResidenceDeleteEvent event) {
         this.event = event;
+        cause = new ElementTag(event.getCause());
         fire(event);
     }
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceGetsDeletedScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceGetsDeletedScriptEvent.java
@@ -15,11 +15,10 @@ public class ResidenceGetsDeletedScriptEvent extends BukkitScriptEvent implement
     // <--[event]
     // @Events
     // residence gets deleted
-    // residence get deleted
     //
-    // @Switch cause:<cause> to only process the event if the cause equals specified cause
+    // @Switch cause:<cause> to only process the event if the cause matches specified cause.
     //
-    // @Triggers when a player deletes a Residence.
+    // @Triggers when a Residence gets deleted.
     //
     // @Context
     // <context.cause> Returns the cause of deletion. ( Available causes: PLAYER_DELETE, OTHER, LEASE_EXPIRE )
@@ -34,7 +33,7 @@ public class ResidenceGetsDeletedScriptEvent extends BukkitScriptEvent implement
     // -->
 
     public ResidenceGetsDeletedScriptEvent() {
-        registerCouldMatcher("residence gets deleted"); registerCouldMatcher("residence get deleted");
+        registerCouldMatcher("residence gets deleted");
         registerSwitches("cause");
     }
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceGetsDeletedScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceGetsDeletedScriptEvent.java
@@ -1,0 +1,76 @@
+package com.denizenscript.depenizen.bukkit.events.residence;
+
+import com.bekvon.bukkit.residence.event.ResidenceDeleteEvent;
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.scripts.ScriptEntryData;
+import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class ResidenceGetsDeletedScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // residence gets deleted
+    // residence get deleted
+    //
+    // @Switch cause:<cause> to only process the event if the cause equals specified cause
+    //
+    // @Triggers when a player deletes a Residence.
+    //
+    // @Context
+    // <context.cause> Returns the cause of deletion. ( Available causes: PLAYER_DELETE, OTHER, LEASE_EXPIRE )
+    // <context.residence> Returns the ResidenceTag of deleted residence.
+    //
+    // @Plugin Depenizen, Residence
+    //
+    // @Player only when the cause is PLAYER_DELETE.
+    //
+    // @Group Depenizen
+    //
+    // -->
+
+    public ResidenceGetsDeletedScriptEvent() {
+        registerCouldMatcher("residence gets deleted"); registerCouldMatcher("residence get deleted");
+        registerSwitches("cause");
+    }
+
+    public ResidenceDeleteEvent event;
+    public String cause;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runGenericSwitchCheck(path, "cause", cause)) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ScriptEntryData getScriptEntryData() {
+        return new BukkitScriptEntryData(event.getPlayer());
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "cause": return new ElementTag(cause);
+            case "residence": return new ResidenceTag(event.getResidence());
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onResidenceGetsDeleted(ResidenceDeleteEvent event) {
+        if (event.getResidence() == null) {
+            return;
+        }
+        cause = event.getCause().name();
+        this.event = event;
+        fire(event);
+    }
+
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceGetsDeletedScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceGetsDeletedScriptEvent.java
@@ -64,9 +64,6 @@ public class ResidenceGetsDeletedScriptEvent extends BukkitScriptEvent implement
 
     @EventHandler
     public void onResidenceGetsDeleted(ResidenceDeleteEvent event) {
-        if (event.getResidence() == null) {
-            return;
-        }
         cause = event.getCause().name();
         this.event = event;
         fire(event);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
@@ -1,0 +1,65 @@
+package com.denizenscript.depenizen.bukkit.events.residence;
+
+import com.bekvon.bukkit.residence.event.ResidenceRaidEndEvent;
+import com.bekvon.bukkit.residence.protection.ClaimedResidence;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+
+public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // residence raid end
+    // residence raid ends
+    //
+    // @Switch residence:<residence_name> to only process the event if the residence name equals specified name
+    //
+    // @Triggers when a raiding a Residence ends.
+    //
+    // @Context
+    // <context.residence> Returns a ResidenceTag of residence that was being raided.
+    //
+    // @Plugin Depenizen, Residence
+    //
+    // @Group Depenizen
+    //
+    // -->
+
+    public ResidenceRaidEndsScriptEvent() {
+        registerCouldMatcher("residence raid ends"); registerCouldMatcher("residence raid end");
+        registerSwitches("residence");
+    }
+
+    public ResidenceRaidEndEvent event;
+    public ClaimedResidence residence;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runGenericSwitchCheck(path, "residence", residence.getName())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        if (name.equals("residence")) {
+            return new ResidenceTag(residence);
+        }
+        return super.getContext(name);
+    }
+
+    @EventHandler
+    public void onResidenceRaidEndsScriptEvent(ResidenceRaidEndEvent event) {
+        if (event.getRes() == null) {
+            return;
+        }
+        residence = event.getRes();
+        this.event = event;
+        fire(event);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
@@ -2,7 +2,6 @@ package com.denizenscript.depenizen.bukkit.events.residence;
 
 import com.bekvon.bukkit.residence.event.ResidenceRaidEndEvent;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import org.bukkit.event.EventHandler;
@@ -34,10 +33,11 @@ public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements L
     }
 
     public ResidenceRaidEndEvent event;
+    public ResidenceTag residence;
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.tryObjectSwitch("residence", new ElementTag(event.getRes().getName()))) {
+        if (!path.tryObjectSwitch("residence", residence)) {
             return false;
         }
         return super.matches(path);
@@ -46,7 +46,7 @@ public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements L
     @Override
     public ObjectTag getContext(String name) {
         switch (name) {
-            case "residence": return new ResidenceTag(event.getRes());
+            case "residence": return residence;
         }
         return super.getContext(name);
     }
@@ -54,6 +54,7 @@ public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements L
     @EventHandler
     public void onResidenceRaidEndsScriptEvent(ResidenceRaidEndEvent event) {
         this.event = event;
+        residence = new ResidenceTag(event.getRes());
         fire(event);
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
@@ -54,9 +54,6 @@ public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements L
 
     @EventHandler
     public void onResidenceRaidEndsScriptEvent(ResidenceRaidEndEvent event) {
-        if (event.getRes() == null) {
-            return;
-        }
         residence = event.getRes();
         this.event = event;
         fire(event);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
@@ -1,7 +1,6 @@
 package com.denizenscript.depenizen.bukkit.events.residence;
 
 import com.bekvon.bukkit.residence.event.ResidenceRaidEndEvent;
-import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
@@ -20,7 +19,7 @@ public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements L
     // @Triggers when a raiding a Residence ends.
     //
     // @Context
-    // <context.residence> Returns a ResidenceTag of residence that was being raided.
+    // <context.residence> Returns a ResidenceTag of the residence that was being raided.
     //
     // @Plugin Depenizen, Residence
     //
@@ -34,11 +33,10 @@ public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements L
     }
 
     public ResidenceRaidEndEvent event;
-    public ClaimedResidence residence;
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!runGenericSwitchCheck(path, "residence", residence.getName())) {
+        if (!runGenericSwitchCheck(path, "residence", event.getRes().getName())) {
             return false;
         }
         return super.matches(path);
@@ -47,14 +45,13 @@ public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements L
     @Override
     public ObjectTag getContext(String name) {
         switch (name) {
-            case "residence": return new ResidenceTag(residence);
+            case "residence": return new ResidenceTag(event.getRes());
         }
         return super.getContext(name);
     }
 
     @EventHandler
     public void onResidenceRaidEndsScriptEvent(ResidenceRaidEndEvent event) {
-        residence = event.getRes();
         this.event = event;
         fire(event);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
@@ -13,10 +13,9 @@ public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements L
 
     // <--[event]
     // @Events
-    // residence raid end
     // residence raid ends
     //
-    // @Switch residence:<residence_name> to only process the event if the residence name equals specified name
+    // @Switch residence:<residence_name> to only process the event if the residence name matches specified name.
     //
     // @Triggers when a raiding a Residence ends.
     //
@@ -30,7 +29,7 @@ public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements L
     // -->
 
     public ResidenceRaidEndsScriptEvent() {
-        registerCouldMatcher("residence raid ends"); registerCouldMatcher("residence raid end");
+        registerCouldMatcher("residence raid ends");
         registerSwitches("residence");
     }
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
@@ -2,6 +2,7 @@ package com.denizenscript.depenizen.bukkit.events.residence;
 
 import com.bekvon.bukkit.residence.event.ResidenceRaidEndEvent;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import org.bukkit.event.EventHandler;
@@ -36,7 +37,7 @@ public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements L
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!runGenericSwitchCheck(path, "residence", event.getRes().getName())) {
+        if (!path.tryObjectSwitch("residence", new ElementTag(event.getRes().getName()))) {
             return false;
         }
         return super.matches(path);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidEndsScriptEvent.java
@@ -47,8 +47,8 @@ public class ResidenceRaidEndsScriptEvent extends BukkitScriptEvent implements L
 
     @Override
     public ObjectTag getContext(String name) {
-        if (name.equals("residence")) {
-            return new ResidenceTag(residence);
+        switch (name) {
+            case "residence": return new ResidenceTag(residence);
         }
         return super.getContext(name);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
@@ -1,8 +1,6 @@
 package com.denizenscript.depenizen.bukkit.events.residence;
 
 import com.bekvon.bukkit.residence.event.ResidenceRaidStartEvent;
-import com.bekvon.bukkit.residence.raid.RaidAttacker;
-import com.bekvon.bukkit.residence.raid.RaidDefender;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
@@ -10,7 +8,7 @@ import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-
+import java.util.UUID;
 
 public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements Listener {
 
@@ -18,14 +16,16 @@ public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements
     // @Events
     // residence raid starts
     //
+    // @Cancellable true
+    //
     // @Switch residence:<residence_name> to only process the event if the residence name matches specified name.
     //
     // @Triggers when a player(s) starts raiding a Residence.
     //
     // @Context
-    // <context.residence> Returns a ResidenceTag of residence that is being attacked.
-    // <context.defenders> Returns a ListTag(PlayerTag) of players defending the Residence.
-    // <context.attackers> Returns a ListTag(PlayerTag) of players attacking the Residence.
+    // <context.residence> Returns a ResidenceTag of the residence that is being attacked.
+    // <context.defenders> Returns a ListTag(PlayerTag) of the players defending the Residence.
+    // <context.attackers> Returns a ListTag(PlayerTag) of the players attacking the Residence.
     //
     // @Plugin Depenizen, Residence
     //
@@ -39,6 +39,7 @@ public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements
     }
 
     public ResidenceRaidStartEvent event;
+    public ResidenceTag residence;
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -53,26 +54,25 @@ public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements
         switch (name) {
             case "attackers":
                 ListTag attackers = new ListTag();
-                for (RaidAttacker player : event.getAttackers().values()) {
-                    attackers.addObject(new PlayerTag(player.getPlayer().getPlayer()));
+                for (UUID uuid : event.getAttackers().keySet()) {
+                    attackers.addObject(new PlayerTag(uuid));
                 }
                 return attackers;
             case "defenders":
                 ListTag defenders = new ListTag();
-                for (RaidDefender player : event.getDefenders().values()) {
-                    defenders.addObject(new PlayerTag(player.getPlayer().getPlayer()));
+                for (UUID uuid : event.getDefenders().keySet()) {
+                    defenders.addObject(new PlayerTag(uuid));
                 }
                 return defenders;
-            case "residence":
-                return new ResidenceTag(event.getRes());
-            default:
-                return super.getContext(name);
+            case "residence": return residence;
         }
+        return super.getContext(name);
     }
 
     @EventHandler
     public void onResidenceRaidStartsScriptEvent(ResidenceRaidStartEvent event) {
         this.event = event;
+        residence = new ResidenceTag(event.getRes());
         fire(event);
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
@@ -16,10 +16,9 @@ public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements
 
     // <--[event]
     // @Events
-    // residence raid start
     // residence raid starts
     //
-    // @Switch residence:<residence_name> to only process the event if the residence name equals specified name
+    // @Switch residence:<residence_name> to only process the event if the residence name matches specified name.
     //
     // @Triggers when a player(s) starts raiding a Residence.
     //
@@ -35,7 +34,7 @@ public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements
     // -->
 
     public ResidenceRaidStartsScriptEvent() {
-        registerCouldMatcher("residence raid starts"); registerCouldMatcher("residence raid start");
+        registerCouldMatcher("residence raid starts");
         registerSwitches("residence");
     }
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
@@ -3,6 +3,7 @@ package com.denizenscript.depenizen.bukkit.events.residence;
 import com.bekvon.bukkit.residence.event.ResidenceRaidStartEvent;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
@@ -43,7 +44,7 @@ public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!runGenericSwitchCheck(path, "residence", event.getRes().getName())) {
+        if (!path.tryObjectSwitch("residence", new ElementTag(event.getRes().getName()))) {
             return false;
         }
         return super.matches(path);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
@@ -57,14 +57,14 @@ public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements
         switch (name) {
             case "attackers":
                 attackers = new ListTag();
-                for (RaidAttacker p : event.getAttackers().values()) {
-                    attackers.addObject(new PlayerTag(p.getPlayer().getPlayer()));
+                for (RaidAttacker player : event.getAttackers().values()) {
+                    attackers.addObject(new PlayerTag(player.getPlayer().getPlayer()));
                 }
                 return attackers;
             case "defenders":
                 defenders = new ListTag();
-                for (RaidDefender p : event.getDefenders().values()) {
-                    defenders.addObject(new PlayerTag(p.getPlayer().getPlayer()));
+                for (RaidDefender player : event.getDefenders().values()) {
+                    defenders.addObject(new PlayerTag(player.getPlayer().getPlayer()));
                 }
                 return defenders;
             case "residence":

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
@@ -3,7 +3,6 @@ package com.denizenscript.depenizen.bukkit.events.residence;
 import com.bekvon.bukkit.residence.event.ResidenceRaidStartEvent;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
@@ -44,7 +43,7 @@ public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.tryObjectSwitch("residence", new ElementTag(event.getRes().getName()))) {
+        if (!path.tryObjectSwitch("residence", residence)) {
             return false;
         }
         return super.matches(path);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
@@ -39,9 +39,6 @@ public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements
     }
 
     public ResidenceRaidStartEvent event;
-    public ResidenceTag residence;
-    public ListTag attackers;
-    public ListTag defenders;
 
     @Override
     public boolean matches(ScriptPath path) {
@@ -55,13 +52,13 @@ public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements
     public ObjectTag getContext(String name) {
         switch (name) {
             case "attackers":
-                attackers = new ListTag();
+                ListTag attackers = new ListTag();
                 for (RaidAttacker player : event.getAttackers().values()) {
                     attackers.addObject(new PlayerTag(player.getPlayer().getPlayer()));
                 }
                 return attackers;
             case "defenders":
-                defenders = new ListTag();
+                ListTag defenders = new ListTag();
                 for (RaidDefender player : event.getDefenders().values()) {
                     defenders.addObject(new PlayerTag(player.getPlayer().getPlayer()));
                 }
@@ -75,9 +72,6 @@ public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements
 
     @EventHandler
     public void onResidenceRaidStartsScriptEvent(ResidenceRaidStartEvent event) {
-        if (event.getRes() == null) {
-            return;
-        }
         this.event = event;
         fire(event);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/residence/ResidenceRaidStartsScriptEvent.java
@@ -1,0 +1,85 @@
+package com.denizenscript.depenizen.bukkit.events.residence;
+
+import com.bekvon.bukkit.residence.event.ResidenceRaidStartEvent;
+import com.bekvon.bukkit.residence.raid.RaidAttacker;
+import com.bekvon.bukkit.residence.raid.RaidDefender;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
+import com.denizenscript.denizen.events.BukkitScriptEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+
+public class ResidenceRaidStartsScriptEvent extends BukkitScriptEvent implements Listener {
+
+    // <--[event]
+    // @Events
+    // residence raid start
+    // residence raid starts
+    //
+    // @Switch residence:<residence_name> to only process the event if the residence name equals specified name
+    //
+    // @Triggers when a player(s) starts raiding a Residence.
+    //
+    // @Context
+    // <context.residence> Returns a ResidenceTag of residence that is being attacked.
+    // <context.defenders> Returns a ListTag(PlayerTag) of players defending the Residence.
+    // <context.attackers> Returns a ListTag(PlayerTag) of players attacking the Residence.
+    //
+    // @Plugin Depenizen, Residence
+    //
+    // @Group Depenizen
+    //
+    // -->
+
+    public ResidenceRaidStartsScriptEvent() {
+        registerCouldMatcher("residence raid starts"); registerCouldMatcher("residence raid start");
+        registerSwitches("residence");
+    }
+
+    public ResidenceRaidStartEvent event;
+    public ResidenceTag residence;
+    public ListTag attackers;
+    public ListTag defenders;
+
+    @Override
+    public boolean matches(ScriptPath path) {
+        if (!runGenericSwitchCheck(path, "residence", event.getRes().getName())) {
+            return false;
+        }
+        return super.matches(path);
+    }
+
+    @Override
+    public ObjectTag getContext(String name) {
+        switch (name) {
+            case "attackers":
+                attackers = new ListTag();
+                for (RaidAttacker p : event.getAttackers().values()) {
+                    attackers.addObject(new PlayerTag(p.getPlayer().getPlayer()));
+                }
+                return attackers;
+            case "defenders":
+                defenders = new ListTag();
+                for (RaidDefender p : event.getDefenders().values()) {
+                    defenders.addObject(new PlayerTag(p.getPlayer().getPlayer()));
+                }
+                return defenders;
+            case "residence":
+                return new ResidenceTag(event.getRes());
+            default:
+                return super.getContext(name);
+        }
+    }
+
+    @EventHandler
+    public void onResidenceRaidStartsScriptEvent(ResidenceRaidStartEvent event) {
+        if (event.getRes() == null) {
+            return;
+        }
+        this.event = event;
+        fire(event);
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
@@ -117,7 +117,7 @@ public class ResidenceTag implements ObjectTag {
         return tagProcessor.getObjectAttribute(this, attribute);
     }
 
-    public static void registerTags() {
+    public static void register() {
 
         // <--[tag]
         // @attribute <ResidenceTag.name>
@@ -135,7 +135,7 @@ public class ResidenceTag implements ObjectTag {
         // @returns PlayerTag
         // @plugin Depenizen, Residence
         // @description
-        // Returns a PlayerTag of owner in this Residence.
+        // Returns the owner of the Residence.
         // -->
         tagProcessor.registerTag(PlayerTag.class, "owner", (attribute, object) -> {
             return new PlayerTag(object.getResidence().getOwnerUUID());
@@ -143,10 +143,10 @@ public class ResidenceTag implements ObjectTag {
 
         // <--[tag]
         // @attribute <ResidenceTag.subzones>
-        // @returns ListTag
+        // @returns ListTag(ResidenceTag)
         // @plugin Depenizen, Residence
         // @description
-        // Returns a ListTag(ResidenceTag) of subzones in this Residence.
+        // Returns a list of subzones in this Residence.
         // -->
         tagProcessor.registerTag(ListTag.class, "subzones", (attribute, object) -> {
             ListTag list = new ListTag();
@@ -161,7 +161,7 @@ public class ResidenceTag implements ObjectTag {
         // @returns CuboidTag
         // @plugin Depenizen, Residence
         // @description
-        // Returns a CuboidTag of this Residences area.
+        // Returns the area of the Residences.
         // -->
         tagProcessor.registerTag(CuboidTag.class, "area", (attribute, object) -> {
             CuboidArea area = object.getResidence().getMainArea();
@@ -175,12 +175,8 @@ public class ResidenceTag implements ObjectTag {
         // @description
         // Returns boolean whether the specified location is within this Residence.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "is_within", (attribute, object) -> {
-            if (attribute.hasParam()) {
-                LocationTag location = attribute.paramAsType(LocationTag.class);
-                return new ElementTag(object.getResidence().containsLoc(location));
-            }
-            return null;
+        tagProcessor.registerTag(ElementTag.class, LocationTag.class, "is_within", (attribute, object, loc) -> {
+            return new ElementTag(object.getResidence().containsLoc(loc));
         });
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
@@ -17,6 +17,7 @@ import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 
 public class ResidenceTag implements ObjectTag {
+
     public static ObjectTagProcessor<ResidenceTag> tagProcessor = new ObjectTagProcessor<>();
 
     // <--[ObjectType]

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
@@ -1,7 +1,6 @@
 package com.denizenscript.depenizen.bukkit.objects.residence;
 
 import com.bekvon.bukkit.residence.Residence;
-import com.bekvon.bukkit.residence.containers.ResidencePlayer;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.bekvon.bukkit.residence.protection.CuboidArea;
 import com.denizenscript.denizen.objects.CuboidTag;
@@ -150,8 +149,8 @@ public class ResidenceTag implements ObjectTag {
         // -->
         tagProcessor.registerTag(ListTag.class, "subzones", (attribute, object) -> {
             ListTag list = new ListTag();
-            for ( ClaimedResidence subzone : object.getResidence().getSubzones() ) {
-                list.addObject( new ResidenceTag(subzone));
+            for (ClaimedResidence subzone : object.getResidence().getSubzones()) {
+                list.addObject(new ResidenceTag(subzone));
             }
             return list;
         });
@@ -166,21 +165,6 @@ public class ResidenceTag implements ObjectTag {
         tagProcessor.registerTag(CuboidTag.class, "area", (attribute, object) -> {
             CuboidArea area = object.getResidence().getMainArea();
             return new CuboidTag(area.getLowLocation(), area.getHighLocation());
-        });
-
-        // <--[tag]
-        // @attribute <ResidenceTag.trusted_players>
-        // @returns ListTag(PlayerTag)
-        // @plugin Depenizen, Residence
-        // @description
-        // Returns a ListTag(PlayerTag) of trusted players in this Residence.
-        // -->
-        tagProcessor.registerTag(ListTag.class, "trusted_players", (attribute, object) -> {
-            ListTag players = new ListTag();
-            for (ResidencePlayer p : object.getResidence().getTrustedPlayers() ) {
-                players.addObject(new PlayerTag(p.getPlayer()));
-            }
-            return players;
         });
 
         // <--[tag]

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
@@ -174,7 +174,7 @@ public class ResidenceTag implements ObjectTag {
         // @returns ElementTag(Boolean)
         // @plugin Depenizen, Residence
         // @description
-        // Returns boolean whether the specified location is within this Residence.
+        // Returns whether the specified location is within this Residence.
         // -->
         tagProcessor.registerTag(ElementTag.class, LocationTag.class, "is_within", (attribute, object, loc) -> {
             return new ElementTag(object.getResidence().containsLoc(loc));

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
@@ -1,18 +1,24 @@
 package com.denizenscript.depenizen.bukkit.objects.residence;
 
 import com.bekvon.bukkit.residence.Residence;
+import com.bekvon.bukkit.residence.containers.ResidencePlayer;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
+import com.bekvon.bukkit.residence.protection.CuboidArea;
+import com.denizenscript.denizen.objects.CuboidTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Fetchable;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 
 public class ResidenceTag implements ObjectTag {
+    public static ObjectTagProcessor<ResidenceTag> tagProcessor = new ObjectTagProcessor<>();
 
     // <--[ObjectType]
     // @name ResidenceTag
@@ -108,44 +114,88 @@ public class ResidenceTag implements ObjectTag {
 
     @Override
     public ObjectTag getObjectAttribute(Attribute attribute) {
-        if (attribute == null) {
-            return null;
-        }
+        return tagProcessor.getObjectAttribute(this, attribute);
+    }
+
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <ResidenceTag.name>
         // @returns ElementTag
         // @plugin Depenizen, Residence
         // @description
-        // Returns the name of the residence.
+        // Returns the name of this Residence.
         // -->
-        if (attribute.startsWith("name")) {
-            return new ElementTag(residence.getName()).getObjectAttribute(attribute.fulfill(1));
-        }
+        tagProcessor.registerTag(ElementTag.class, "name", (attribute, object) -> {
+            return new ElementTag(object.getResidence().getName());
+        });
 
         // <--[tag]
         // @attribute <ResidenceTag.owner>
         // @returns PlayerTag
         // @plugin Depenizen, Residence
         // @description
-        // Returns the owner of the residence.
+        // Returns a PlayerTag of owner in this Residence.
         // -->
-        else if (attribute.startsWith("owner")) {
-            return new PlayerTag(residence.getOwnerUUID()).getObjectAttribute(attribute.fulfill(1));
-        }
+        tagProcessor.registerTag(PlayerTag.class, "owner", (attribute, object) -> {
+            return new PlayerTag(object.getResidence().getOwnerUUID());
+        });
+
+        // <--[tag]
+        // @attribute <ResidenceTag.subzones>
+        // @returns ListTag
+        // @plugin Depenizen, Residence
+        // @description
+        // Returns a ListTag(ResidenceTag) of subzones in this Residence.
+        // -->
+        tagProcessor.registerTag(ListTag.class, "subzones", (attribute, object) -> {
+            ListTag list = new ListTag();
+            for ( ClaimedResidence subzone : object.getResidence().getSubzones() ) {
+                list.addObject( new ResidenceTag(subzone));
+            }
+            return list;
+        });
+
+        // <--[tag]
+        // @attribute <ResidenceTag.area>
+        // @returns CuboidTag
+        // @plugin Depenizen, Residence
+        // @description
+        // Returns a CuboidTag of this Residences area.
+        // -->
+        tagProcessor.registerTag(CuboidTag.class, "area", (attribute, object) -> {
+            CuboidArea area = object.getResidence().getMainArea();
+            return new CuboidTag(area.getLowLocation(), area.getHighLocation());
+        });
+
+        // <--[tag]
+        // @attribute <ResidenceTag.trusted_players>
+        // @returns ListTag(PlayerTag)
+        // @plugin Depenizen, Residence
+        // @description
+        // Returns a ListTag(PlayerTag) of trusted players in this Residence.
+        // -->
+        tagProcessor.registerTag(ListTag.class, "trusted_players", (attribute, object) -> {
+            ListTag players = new ListTag();
+            for (ResidencePlayer p : object.getResidence().getTrustedPlayers() ) {
+                players.addObject(new PlayerTag(p.getPlayer()));
+            }
+            return players;
+        });
 
         // <--[tag]
         // @attribute <ResidenceTag.is_within[<location>]>
         // @returns ElementTag(Boolean)
         // @plugin Depenizen, Residence
         // @description
-        // Returns whether the specified location is within this Residence.
+        // Returns boolean whether the specified location is within this Residence.
         // -->
-        else if (attribute.startsWith("is_within") && attribute.hasParam()) {
-            LocationTag location = attribute.paramAsType(LocationTag.class);
-            return new ElementTag(residence.containsLoc(location)).getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return new ElementTag(identify()).getObjectAttribute(attribute);
+        tagProcessor.registerTag(ElementTag.class, "is_within", (attribute, object) -> {
+            if (attribute.hasParam()) {
+                LocationTag location = attribute.paramAsType(LocationTag.class);
+                return new ElementTag(object.getResidence().containsLoc(location));
+            }
+            return null;
+        });
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/residence/ResidenceTag.java
@@ -6,6 +6,7 @@ import com.bekvon.bukkit.residence.protection.CuboidArea;
 import com.denizenscript.denizen.objects.CuboidTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.Fetchable;
 import com.denizenscript.denizencore.objects.ObjectTag;
@@ -178,5 +179,14 @@ public class ResidenceTag implements ObjectTag {
         tagProcessor.registerTag(ElementTag.class, LocationTag.class, "is_within", (attribute, object, loc) -> {
             return new ElementTag(object.getResidence().containsLoc(loc));
         });
+    }
+
+    @Override
+    public boolean advancedMatches(String matcher) {
+        String matcherLow = CoreUtilities.toLowerCase(matcher);
+        if (matcherLow.equals("residence")) {
+            return true;
+        }
+        return ScriptEvent.runGenericCheck(matcherLow, getResidence().getName());
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidenceLocationExtensions.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidenceLocationExtensions.java
@@ -6,7 +6,8 @@ import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 
-public class ResidenceLocationProperties {
+public class ResidenceLocationExtensions {
+
     public static void register() {
 
         // <--[tag]
@@ -14,7 +15,7 @@ public class ResidenceLocationProperties {
         // @returns ElementTag(Boolean)
         // @plugin Depenizen, Residence
         // @description
-        // Returns boolean whether the location has a Residence.
+        // Returns whether the location has a Residence.
         // -->
         LocationTag.tagProcessor.registerTag(ElementTag.class, "has_residence", (attribute, location) -> {
             ClaimedResidence res = Residence.getInstance().getResidenceManager().getByLoc(location);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidenceLocationProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidenceLocationProperties.java
@@ -55,7 +55,7 @@ public class ResidenceLocationProperties implements Property {
         // @returns ElementTag(Boolean)
         // @plugin Depenizen, Residence
         // @description
-        // Returns if the location has a residence.
+        // Returns boolean whether the location has a Residence.
         // -->
         PropertyParser.registerTag(ResidenceLocationProperties.class, ElementTag.class, "has_residence", (attribute, object) -> {
             ClaimedResidence res = Residence.getInstance().getResidenceManager().getByLoc(object.location);
@@ -67,7 +67,7 @@ public class ResidenceLocationProperties implements Property {
         // @returns ResidenceTag
         // @plugin Depenizen, Residence
         // @description
-        // Returns the residence contained by this location.
+        // Returns the Residence contained by this location.
         // -->
         PropertyParser.registerTag(ResidenceLocationProperties.class, ResidenceTag.class, "residence", (attribute, object) -> {
             ClaimedResidence res = Residence.getInstance().getResidenceManager().getByLoc(object.location);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidenceLocationProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidenceLocationProperties.java
@@ -4,11 +4,11 @@ import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.tags.Attribute;
 
 public class ResidenceLocationProperties implements Property {
 
@@ -48,8 +48,8 @@ public class ResidenceLocationProperties implements Property {
 
     LocationTag location;
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
+    public static void registerTags() {
+
         // <--[tag]
         // @attribute <LocationTag.has_residence>
         // @returns ElementTag(Boolean)
@@ -57,10 +57,10 @@ public class ResidenceLocationProperties implements Property {
         // @description
         // Returns if the location has a residence.
         // -->
-        if (attribute.startsWith("has_residence")) {
-            ClaimedResidence res = Residence.getInstance().getResidenceManager().getByLoc(location);
-            return new ElementTag(res != null).getObjectAttribute(attribute.fulfill(1));
-        }
+        PropertyParser.registerTag(ResidenceLocationProperties.class, ElementTag.class, "has_residence", (attribute, object) -> {
+            ClaimedResidence res = Residence.getInstance().getResidenceManager().getByLoc(object.location);
+            return new ElementTag(res != null);
+        });
 
         // <--[tag]
         // @attribute <LocationTag.residence>
@@ -69,15 +69,13 @@ public class ResidenceLocationProperties implements Property {
         // @description
         // Returns the residence contained by this location.
         // -->
-        if (attribute.startsWith("residence")) {
-            ClaimedResidence res = Residence.getInstance().getResidenceManager().getByLoc(location);
+        PropertyParser.registerTag(ResidenceLocationProperties.class, ResidenceTag.class, "residence", (attribute, object) -> {
+            ClaimedResidence res = Residence.getInstance().getResidenceManager().getByLoc(object.location);
             if (res != null) {
-                return new ResidenceTag(res).getObjectAttribute(attribute.fulfill(1));
+                return new ResidenceTag(res);
             }
             return null;
-        }
-
-        return null;
+        });
     }
 
     @Override

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidenceLocationProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidenceLocationProperties.java
@@ -2,52 +2,11 @@ package com.denizenscript.depenizen.bukkit.properties.residence;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
-import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.objects.Mechanism;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.objects.ObjectTag;
 
-public class ResidenceLocationProperties implements Property {
-
-    @Override
-    public String getPropertyString() {
-        return null;
-    }
-
-    @Override
-    public String getPropertyId() {
-        return "ResidenceLocation";
-    }
-
-    public static boolean describes(ObjectTag object) {
-        return object instanceof LocationTag;
-    }
-
-    public static ResidenceLocationProperties getFrom(ObjectTag object) {
-        if (!describes(object)) {
-            return null;
-        }
-        else {
-            return new ResidenceLocationProperties((LocationTag) object);
-        }
-    }
-
-    public static final String[] handledTags = new String[] {
-            "has_residence", "residence"
-    };
-
-    public static final String[] handledMechs = new String[] {
-    }; // None
-
-    private ResidenceLocationProperties(LocationTag location) {
-        this.location = location;
-    }
-
-    LocationTag location;
-
+public class ResidenceLocationProperties {
     public static void register() {
 
         // <--[tag]
@@ -57,8 +16,8 @@ public class ResidenceLocationProperties implements Property {
         // @description
         // Returns boolean whether the location has a Residence.
         // -->
-        PropertyParser.registerTag(ResidenceLocationProperties.class, ElementTag.class, "has_residence", (attribute, object) -> {
-            ClaimedResidence res = Residence.getInstance().getResidenceManager().getByLoc(object.location);
+        LocationTag.tagProcessor.registerTag(ElementTag.class, "has_residence", (attribute, location) -> {
+            ClaimedResidence res = Residence.getInstance().getResidenceManager().getByLoc(location);
             return new ElementTag(res != null);
         });
 
@@ -69,17 +28,12 @@ public class ResidenceLocationProperties implements Property {
         // @description
         // Returns the Residence contained by this location.
         // -->
-        PropertyParser.registerTag(ResidenceLocationProperties.class, ResidenceTag.class, "residence", (attribute, object) -> {
-            ClaimedResidence res = Residence.getInstance().getResidenceManager().getByLoc(object.location);
+        LocationTag.tagProcessor.registerTag(ResidenceTag.class, "residence", (attribute, location) -> {
+            ClaimedResidence res = Residence.getInstance().getResidenceManager().getByLoc(location);
             if (res != null) {
                 return new ResidenceTag(res);
             }
             return null;
         });
-    }
-
-    @Override
-    public void adjust(Mechanism mechanism) {
-        ElementTag value = mechanism.getValue();
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidenceLocationProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidenceLocationProperties.java
@@ -48,7 +48,7 @@ public class ResidenceLocationProperties implements Property {
 
     LocationTag location;
 
-    public static void registerTags() {
+    public static void register() {
 
         // <--[tag]
         // @attribute <LocationTag.has_residence>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidencePlayerExtensions.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidencePlayerExtensions.java
@@ -1,15 +1,14 @@
 package com.denizenscript.depenizen.bukkit.properties.residence;
 
 import com.bekvon.bukkit.residence.Residence;
-import com.bekvon.bukkit.residence.containers.ResidencePlayer;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
-import org.bukkit.entity.Player;
 
-public class ResidencePlayerProperties {
+public class ResidencePlayerExtensions {
+
     public static void register() {
 
         // <--[tag]
@@ -17,10 +16,10 @@ public class ResidencePlayerProperties {
         // @returns ElementTag(Boolean)
         // @plugin Depenizen, Residence
         // @description
-        // Returns boolean whether the player has a main Residence.
+        // Returns whether the player has a main Residence.
         // -->
         PlayerTag.tagProcessor.registerTag(ElementTag.class, "has_main_residence", (attribute, player) -> {
-            ClaimedResidence res = Residence.getInstance().getPlayerManager().getResidencePlayer(player.getName()).getMainResidence();
+            ClaimedResidence res = Residence.getInstance().getPlayerManager().getResidencePlayer(player.getUUID()).getMainResidence();
             return new ElementTag(res != null);
         });
 
@@ -32,7 +31,7 @@ public class ResidencePlayerProperties {
         // Returns the player's current main Residence if they have one.
         // -->
         PlayerTag.tagProcessor.registerTag(ResidenceTag.class, "main_residence", (attribute, player) -> {
-            ClaimedResidence res = Residence.getInstance().getPlayerManager().getResidencePlayer(player.getName()).getMainResidence();
+            ClaimedResidence res = Residence.getInstance().getPlayerManager().getResidencePlayer(player.getUUID()).getMainResidence();
             if (res != null) {
                 return new ResidenceTag(res);
             }
@@ -48,7 +47,7 @@ public class ResidencePlayerProperties {
         // -->
         PlayerTag.tagProcessor.registerTag(ListTag.class, "residences", (attribute, player) -> {
             ListTag list = new ListTag();
-            for (ClaimedResidence res : Residence.getInstance().getPlayerManager().getResidencePlayer(player.getName()).getResList()) {
+            for (ClaimedResidence res : Residence.getInstance().getPlayerManager().getResidencePlayer(player.getUUID()).getResList()) {
                 list.addObject(new ResidenceTag(res));
             }
             return list;

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidencePlayerProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidencePlayerProperties.java
@@ -55,7 +55,7 @@ public class ResidencePlayerProperties implements Property {
 
     ResidencePlayer player;
 
-    public static void registerTags() {
+    public static void register() {
 
         // <--[tag]
         // @attribute <PlayerTag.has_main_residence>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidencePlayerProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidencePlayerProperties.java
@@ -6,55 +6,10 @@ import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
-import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
-import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
+import org.bukkit.entity.Player;
 
-public class ResidencePlayerProperties implements Property {
-
-    @Override
-    public String getPropertyString() {
-        return null;
-    }
-
-    @Override
-    public String getPropertyId() {
-        return "ResidencePlayer";
-    }
-
-    @Override
-    public void adjust(Mechanism mechanism) {
-        // None
-    }
-
-    public static boolean describes(ObjectTag object) {
-        return object instanceof PlayerTag;
-    }
-
-    public static ResidencePlayerProperties getFrom(ObjectTag object) {
-        if (!describes(object)) {
-            return null;
-        }
-        else {
-            return new ResidencePlayerProperties((PlayerTag) object);
-        }
-    }
-
-    public static final String[] handledTags = new String[] {
-            "has_main_residence", "main_residence", "residences"
-    };
-
-    public static final String[] handledMechs = new String[] {
-    }; // None
-
-    private ResidencePlayerProperties(PlayerTag player) {
-        this.player = Residence.getInstance().getPlayerManagerAPI().getResidencePlayer(player.getName());
-    }
-
-    ResidencePlayer player;
-
+public class ResidencePlayerProperties {
     public static void register() {
 
         // <--[tag]
@@ -64,8 +19,8 @@ public class ResidencePlayerProperties implements Property {
         // @description
         // Returns boolean whether the player has a main Residence.
         // -->
-        PropertyParser.registerTag(ResidencePlayerProperties.class, ElementTag.class, "has_main_residence", (attribute, object) -> {
-            ClaimedResidence res = object.player.getMainResidence();
+        PlayerTag.tagProcessor.registerTag(ElementTag.class, "has_main_residence", (attribute, player) -> {
+            ClaimedResidence res = Residence.getInstance().getPlayerManager().getResidencePlayer(player.getName()).getMainResidence();
             return new ElementTag(res != null);
         });
 
@@ -76,8 +31,8 @@ public class ResidencePlayerProperties implements Property {
         // @description
         // Returns the player's current main Residence if they have one.
         // -->
-        PropertyParser.registerTag(ResidencePlayerProperties.class, ResidenceTag.class, "main_residence", (attribute, object) -> {
-            ClaimedResidence res = object.player.getMainResidence();
+        PlayerTag.tagProcessor.registerTag(ResidenceTag.class, "main_residence", (attribute, player) -> {
+            ClaimedResidence res = Residence.getInstance().getPlayerManager().getResidencePlayer(player.getName()).getMainResidence();
             if (res != null) {
                 return new ResidenceTag(res);
             }
@@ -91,9 +46,9 @@ public class ResidencePlayerProperties implements Property {
         // @description
         // Returns the player's current list of Residences.
         // -->
-        PropertyParser.registerTag(ResidencePlayerProperties.class, ListTag.class, "residences", (attribute, object) -> {
+        PlayerTag.tagProcessor.registerTag(ListTag.class, "residences", (attribute, player) -> {
             ListTag list = new ListTag();
-            for (ClaimedResidence res : object.player.getResList()) {
+            for (ClaimedResidence res : Residence.getInstance().getPlayerManager().getResidencePlayer(player.getName()).getResList()) {
                 list.addObject(new ResidenceTag(res));
             }
             return list;

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidencePlayerProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidencePlayerProperties.java
@@ -7,7 +7,7 @@ import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.objects.properties.Property;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.depenizen.bukkit.objects.residence.ResidenceTag;
@@ -55,8 +55,7 @@ public class ResidencePlayerProperties implements Property {
 
     ResidencePlayer player;
 
-    @Override
-    public ObjectTag getObjectAttribute(Attribute attribute) {
+    public static void registerTags() {
 
         // <--[tag]
         // @attribute <PlayerTag.has_main_residence>
@@ -65,10 +64,10 @@ public class ResidencePlayerProperties implements Property {
         // @description
         // Returns whether the player has a main Residence.
         // -->
-        if (attribute.startsWith("has_main_residence")) {
-            ClaimedResidence residence = player.getMainResidence();
-            return new ElementTag(residence != null).getObjectAttribute(attribute.fulfill(1));
-        }
+        PropertyParser.registerTag(ResidencePlayerProperties.class, ElementTag.class, "has_main_residence", (attribute, object) -> {
+            ClaimedResidence res = object.player.getMainResidence();
+            return new ElementTag(res != null);
+        });
 
         // <--[tag]
         // @attribute <PlayerTag.main_residence>
@@ -77,12 +76,13 @@ public class ResidencePlayerProperties implements Property {
         // @description
         // Returns the player's current main Residence if they have one.
         // -->
-        else if (attribute.startsWith("main_residence")) {
-            ClaimedResidence residence = player.getMainResidence();
-            if (residence != null) {
-                return new ResidenceTag(player.getMainResidence()).getObjectAttribute(attribute.fulfill(1));
+        PropertyParser.registerTag(ResidencePlayerProperties.class, ResidenceTag.class, "main_residence", (attribute, object) -> {
+            ClaimedResidence res = object.player.getMainResidence();
+            if (res != null) {
+                return new ResidenceTag(res);
             }
-        }
+            return null;
+        });
 
         // <--[tag]
         // @attribute <PlayerTag.residences>
@@ -91,15 +91,12 @@ public class ResidencePlayerProperties implements Property {
         // @description
         // Returns the player's current list of Residences.
         // -->
-        else if (attribute.startsWith("residences")) {
+        PropertyParser.registerTag(ResidencePlayerProperties.class, ListTag.class, "residences", (attribute, object) -> {
             ListTag list = new ListTag();
-            for (ClaimedResidence residence : player.getResList()) {
-                list.addObject(new ResidenceTag(residence));
+            for (ClaimedResidence res : object.player.getResList()) {
+                list.addObject(new ResidenceTag(res));
             }
-            return list.getObjectAttribute(attribute.fulfill(1));
-        }
-
-        return null;
-
+            return list;
+        });
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidencePlayerProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/residence/ResidencePlayerProperties.java
@@ -62,7 +62,7 @@ public class ResidencePlayerProperties implements Property {
         // @returns ElementTag(Boolean)
         // @plugin Depenizen, Residence
         // @description
-        // Returns whether the player has a main Residence.
+        // Returns boolean whether the player has a main Residence.
         // -->
         PropertyParser.registerTag(ResidencePlayerProperties.class, ElementTag.class, "has_main_residence", (attribute, object) -> {
             ClaimedResidence res = object.player.getMainResidence();


### PR DESCRIPTION
New events:
```
- residence player creates residence
- residence gets deleted (cause: <cause>)
- residence raid ends (residence: <name>)
- residence raid starts (residence: <name>)
```

New tags:
```
- ResidenceTag.area > Returns CuboidTag of this Residence.
- ResidenceTag.subzones > Returns ListTag(ResidenceTag) of subzones in this Residence.
- residence[<name>] > Returns the ResidenceTag from the given name.
```
Updated tags to the new registerTag format.
Updated Residence dependency to `5.1.0.0`