### PR TITLE
Add ViveCraftSpigotExtensions

### DIFF
--- a/Docs/BukkitPlugins.md
+++ b/Docs/BukkitPlugins.md
@@ -39,6 +39,7 @@ Supported Plugins: (And the sources we acquired Jar files from.)
 - TownyChat (https://github.com/TownyAdvanced/Towny)
 - Vampire (https://www.spigotmc.org/resources/vampire.1906/)
 - ViaVersion (https://www.spigotmc.org/resources/viaversion.19254/)
+- Vivecraft-Spigot-Extensions (https://www.spigotmc.org/resources/vivecraft-spigot-extensions.33166/)
 - WorldEdit (https://dev.bukkit.org/bukkit-plugins/worldedit/)
 - WorldGuard (https://dev.bukkit.org/bukkit-plugins/worldguard/)
 - You may post an issue on the issues page to request support for a plugin!

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,13 @@
             <systemPath>${basedir}/lib/nuvotifier.jar</systemPath>
         </dependency>
         <dependency>
+            <groupId>org.vivecraft</groupId>
+            <artifactId>ViveCraft</artifactId>
+            <version>1.19.1-1</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/lib/ViveCraft.jar</systemPath>
+        </dependency>
+        <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
             <version>7.3.0-SNAPSHOT</version>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/Depenizen.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/Depenizen.java
@@ -134,6 +134,7 @@ public class Depenizen extends JavaPlugin {
         registerBridge("TownyChat", () -> new TownyChatBridge());
         registerBridge("Vampire", () -> new VampireBridge());
         registerBridge("ViaVersion", () -> new ViaVersionBridge());
+        registerBridge("Vivecraft-Spigot-Extensions", () -> new ViveCraftBridge());
         registerBridge("Votifier", () -> new VotifierBridge());
         registerBridge("WorldEdit", () -> new WorldEditBridge());
         registerBridge("WorldGuard", () -> new WorldGuardBridge());

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ViveCraftBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ViveCraftBridge.java
@@ -1,0 +1,32 @@
+package com.denizenscript.depenizen.bukkit.bridges;
+
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.DenizenCore;
+import com.denizenscript.denizencore.objects.ObjectFetcher;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.denizenscript.depenizen.bukkit.Bridge;
+import com.denizenscript.depenizen.bukkit.commands.vivecraft.ViveMirrorCommand;
+import com.denizenscript.depenizen.bukkit.objects.vivecraft.ViveCraftPlayerTag;
+import com.denizenscript.depenizen.bukkit.properties.vivecraft.ViveCraftPlayerProperties;
+import org.bukkit.entity.Player;
+import org.vivecraft.VSE;
+import org.vivecraft.VivePlayer;
+
+
+public class ViveCraftBridge extends Bridge {
+
+    @Override
+    public void init() {
+        PropertyParser.registerProperty(ViveCraftPlayerProperties.class, PlayerTag.class);
+        ObjectFetcher.registerWithObjectFetcher(ViveCraftPlayerTag.class, ViveCraftPlayerTag.tagProcessor);
+        DenizenCore.commandRegistry.registerCommand(ViveMirrorCommand.class);
+    }
+
+    public static boolean isViveCraftPlayer(Player player) {
+        return VSE.isVive(player);
+    }
+
+    public static VivePlayer getViveCraftPlayer(Player player) {
+        return VSE.vivePlayers.get(player.getUniqueId());
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ViveCraftBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/ViveCraftBridge.java
@@ -1,9 +1,7 @@
 package com.denizenscript.depenizen.bukkit.bridges;
 
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.objects.ObjectFetcher;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.depenizen.bukkit.Bridge;
 import com.denizenscript.depenizen.bukkit.commands.vivecraft.ViveMirrorCommand;
 import com.denizenscript.depenizen.bukkit.objects.vivecraft.ViveCraftPlayerTag;
@@ -12,12 +10,11 @@ import org.bukkit.entity.Player;
 import org.vivecraft.VSE;
 import org.vivecraft.VivePlayer;
 
-
 public class ViveCraftBridge extends Bridge {
 
     @Override
     public void init() {
-        PropertyParser.registerProperty(ViveCraftPlayerProperties.class, PlayerTag.class);
+        ViveCraftPlayerProperties.register();
         ObjectFetcher.registerWithObjectFetcher(ViveCraftPlayerTag.class, ViveCraftPlayerTag.tagProcessor);
         DenizenCore.commandRegistry.registerCommand(ViveMirrorCommand.class);
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
@@ -16,7 +16,6 @@ import org.vivecraft.VivePlayer;
 
 import java.util.List;
 
-
 public class ViveMirrorCommand extends AbstractCommand {
 
     public ViveMirrorCommand() {
@@ -54,7 +53,7 @@ public class ViveMirrorCommand extends AbstractCommand {
 
     public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgLinear @ArgName("npc") @ArgRaw NPCTag npc,
-                                   @ArgPrefixed @ArgName("mirror") @ArgDefaultNull ViveCraftPlayerTag mirror,
+                                   @ArgPrefixed @ArgName("mirror") ViveCraftPlayerTag mirror,
                                    @ArgPrefixed @ArgName("targets") @ArgDefaultNull ListTag targets) {
         if (!(npc.getEntity() instanceof Player)) {
             throw new InvalidArgumentsRuntimeException("NPC must be a PLAYER type NPC.");
@@ -65,9 +64,6 @@ public class ViveMirrorCommand extends AbstractCommand {
             }
             targets = new ListTag();
             targets.addObject(Utilities.getEntryPlayer(scriptEntry));
-        }
-        if (mirror == null) {
-            throw new InvalidArgumentsRuntimeException("Missing ViveCraftPlayerTag input.");
         }
         List<PlayerTag> players = targets.filter(PlayerTag.class, scriptEntry);
         VivePlayer vp = new VivePlayer((Player) npc.getLivingEntity());

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
@@ -28,8 +28,8 @@ public class ViveMirrorCommand extends AbstractCommand {
 
     // <--[command]
     // @Name ViveMirror
-    // @Syntax vivemirror [<npc>] [mirror:<vivecraftplayer>] (targets:{player}/<player>|...)"
-    // @Required 1
+    // @Syntax vivemirror [<npc>] [mirror:<vivecraftplayer>] (targets:{player}/<player>|...)
+    // @Required 2
     // @Maximum 3
     // @Short Mirrors a ViveCraftPlayers pose to the npc, once.
     // @Group ViveCraft
@@ -37,10 +37,10 @@ public class ViveMirrorCommand extends AbstractCommand {
     // @Description
     // Mirrors a ViveCraftPlayers pose to the npc, once.
     //
-    // Ideally should run in a loop.
+    // Ideally should run every tick.
     //
     // Specify a vivecraftplayer that will be mirrored to the NPC.
-    // Optionally, specify a list of targets to show the NPCs pose to. (targets must be in VR to see the effect).
+    // Optionally, specify a list of targets to show the NPCs pose to (targets must be in VR to see the effect).
     //
     // @Usage
     // # Use to mirror the current players pose.
@@ -49,6 +49,8 @@ public class ViveMirrorCommand extends AbstractCommand {
     // @Usage
     // # Use to show your dancing skills to other players.
     // - vivemirror <npc> mirror:<player.vivecraft> targets:<server.online_players>
+    //
+    // -->
 
     public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgLinear @ArgName("npc") @ArgRaw NPCTag npc,

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
@@ -39,8 +39,8 @@ public class ViveMirrorCommand extends AbstractCommand {
     //
     // Ideally should run in a loop.
     //
-    // Optionally, specify a mirror player that will be mirrored to the NPC.
-    // Optionally, specify a list of targets to show the NPCs pose to. (targets must be in VR).
+    // Specify a vivecraftplayer that will be mirrored to the NPC.
+    // Optionally, specify a list of targets to show the NPCs pose to. (targets must be in VR to see the effect).
     //
     // @Usage
     // # Use to mirror the current players pose.

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
@@ -1,0 +1,87 @@
+package com.denizenscript.depenizen.bukkit.commands.vivecraft;
+
+import com.denizenscript.denizen.objects.NPCTag;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizen.utilities.Utilities;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.denizenscript.depenizen.bukkit.bridges.ViveCraftBridge;
+import com.denizenscript.depenizen.bukkit.objects.vivecraft.ViveCraftPlayerTag;
+import org.bukkit.entity.Player;
+import org.vivecraft.VSE;
+import org.vivecraft.VivePlayer;
+
+import java.util.List;
+
+
+public class ViveMirrorCommand extends AbstractCommand {
+
+    public ViveMirrorCommand() {
+        setName("vivemirror");
+        setSyntax("vivemirror [<npc>] (mirror:{<player>}) (targets:{<player>}|...)");
+        setRequiredArguments(1, 3);
+        autoCompile();
+    }
+
+    // <--[command]
+    // @Name ViveMirror
+    // @Syntax vivemirror [<npc>] [mirror:<player>] (targets:{player}/<player>)"
+    // @Required 1
+    // @Maximum 3
+    // @Short Mirrors a ViveCraftPlayers pose to the npc.
+    // @Group ViveCraft
+    //
+    // @Description
+    // Mirrors a ViveCraftPlayers pose to the npc, once.
+    //
+    // Ideally should run in a loop.
+    //
+    // Optionally, specify a mirror player that will be mirrored to the NPC.
+    // Optionally, specify a list of targets to show the NPCs pose to. (targets must be in VR).
+    //
+    // @Usage
+    // # Use to mirror the current players pose.
+    // - vivemirror <npc>
+    //
+    // @Usage
+    // # Use to show your dancing skills to other players
+    // - vivemirror <npc> targets:<server.online_players>
+
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgLinear @ArgName("npc") @ArgRaw NPCTag npc,
+                                   @ArgPrefixed @ArgName("mirror") @ArgDefaultNull ViveCraftPlayerTag mirror,
+                                   @ArgPrefixed @ArgName("targets") @ArgDefaultNull ListTag targets) {
+        if (!(npc.getEntity() instanceof Player)) {
+            throw new InvalidArgumentsRuntimeException("NPC must be a PLAYER type NPC.");
+        }
+        if (targets == null) {
+            if (!Utilities.entryHasPlayer(scriptEntry)) {
+                throw new InvalidArgumentsRuntimeException("Missing player input.");
+            }
+            targets = new ListTag();
+            targets.addObject(Utilities.getEntryPlayer(scriptEntry));
+        }
+        if (mirror == null) {
+            throw new InvalidArgumentsRuntimeException("Missing ViveCraftPlayerTag input.");
+        }
+        List<PlayerTag> players = targets.filter(PlayerTag.class, scriptEntry);
+        VivePlayer vp = new VivePlayer((Player) npc.getLivingEntity());
+        VivePlayer copy = mirror.getVivePlayer();
+        vp.worldScale = copy.worldScale;
+        vp.heightScale = copy.heightScale;
+        vp.hmdData = copy.hmdData;
+        vp.controller0data = copy.controller0data;
+        vp.controller1data = copy.controller1data;
+        for (PlayerTag target : players) {
+            if (ViveCraftBridge.isViveCraftPlayer(target.getPlayerEntity())) {
+                target.getPlayerEntity().sendPluginMessage(VSE.getPlugin(VSE.class), VSE.CHANNEL, vp.getUberPacket());
+            }
+        }
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
@@ -21,8 +21,8 @@ public class ViveMirrorCommand extends AbstractCommand {
 
     public ViveMirrorCommand() {
         setName("vivemirror");
-        setSyntax("vivemirror [<npc>] (mirror:{<player>}) (targets:{<player>}|...)");
-        setRequiredArguments(1, 3);
+        setSyntax("vivemirror [<npc>] [mirror:<vivecraftplayer>] (targets:{player}/<player>|...");
+        setRequiredArguments(2, 3);
         autoCompile();
     }
 
@@ -44,11 +44,11 @@ public class ViveMirrorCommand extends AbstractCommand {
     //
     // @Usage
     // # Use to mirror the current players pose.
-    // - vivemirror <npc>
+    // - vivemirror <npc> mirror:<player.vivecraft>
     //
     // @Usage
     // # Use to show your dancing skills to other players.
-    // - vivemirror <npc> targets:<server.online_players>
+    // - vivemirror <npc> mirror:<player.vivecraft> targets:<server.online_players>
 
     public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgLinear @ArgName("npc") @ArgRaw NPCTag npc,

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
@@ -21,7 +21,7 @@ public class ViveMirrorCommand extends AbstractCommand {
 
     public ViveMirrorCommand() {
         setName("vivemirror");
-        setSyntax("vivemirror [<npc>] [mirror:<vivecraftplayer>] (targets:{player}/<player>|...");
+        setSyntax("vivemirror [<npc>] [mirror:<vivecraftplayer>] (targets:{player}/<player>|...)");
         setRequiredArguments(2, 3);
         autoCompile();
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/vivecraft/ViveMirrorCommand.java
@@ -3,14 +3,11 @@ package com.denizenscript.depenizen.bukkit.commands.vivecraft;
 import com.denizenscript.denizen.objects.NPCTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
-import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.scripts.commands.generator.*;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.depenizen.bukkit.bridges.ViveCraftBridge;
 import com.denizenscript.depenizen.bukkit.objects.vivecraft.ViveCraftPlayerTag;
 import org.bukkit.entity.Player;
@@ -31,10 +28,10 @@ public class ViveMirrorCommand extends AbstractCommand {
 
     // <--[command]
     // @Name ViveMirror
-    // @Syntax vivemirror [<npc>] [mirror:<player>] (targets:{player}/<player>)"
+    // @Syntax vivemirror [<npc>] [mirror:<vivecraftplayer>] (targets:{player}/<player>|...)"
     // @Required 1
     // @Maximum 3
-    // @Short Mirrors a ViveCraftPlayers pose to the npc.
+    // @Short Mirrors a ViveCraftPlayers pose to the npc, once.
     // @Group ViveCraft
     //
     // @Description
@@ -50,7 +47,7 @@ public class ViveMirrorCommand extends AbstractCommand {
     // - vivemirror <npc>
     //
     // @Usage
-    // # Use to show your dancing skills to other players
+    // # Use to show your dancing skills to other players.
     // - vivemirror <npc> targets:<server.online_players>
 
     public static void autoExecute(ScriptEntry scriptEntry,

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/vivecraft/ViveCraftPlayerTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/vivecraft/ViveCraftPlayerTag.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 public class ViveCraftPlayerTag implements ObjectTag {
 
     // <--[ObjectTag]
-    // @name ViveCraftPlayer
+    // @name ViveCraftPlayerTag
     // @prefix vivecraft
     // @base ElementTag
     // @format
@@ -109,7 +109,9 @@ public class ViveCraftPlayerTag implements ObjectTag {
     }
 
     @Override
-    public String toString() { return identify();}
+    public String toString() {
+        return identify();
+    }
 
     @Override
     public ObjectTag setPrefix(String prefix) {
@@ -169,7 +171,7 @@ public class ViveCraftPlayerTag implements ObjectTag {
                     return null;
             }
             if (location == null) {
-                attribute.echoError("Location is not valid. Did a plugin overwrote the data?");
+                attribute.echoError("Location is not valid. Did a plugin overwrite the data?");
                 return null;
             }
             return new LocationTag(location);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/vivecraft/ViveCraftPlayerTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/vivecraft/ViveCraftPlayerTag.java
@@ -1,0 +1,179 @@
+package com.denizenscript.depenizen.bukkit.objects.vivecraft;
+
+import com.denizenscript.denizen.objects.LocationTag;
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.objects.Fetchable;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.tags.ObjectTagProcessor;
+import com.denizenscript.denizencore.tags.TagContext;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.denizenscript.depenizen.bukkit.bridges.ViveCraftBridge;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.vivecraft.VSE;
+import org.vivecraft.VivePlayer;
+
+import java.util.UUID;
+
+public class ViveCraftPlayerTag implements ObjectTag {
+
+    // <--[ObjectTag]
+    // @name ViveCraftPlayer
+    // @prefix vivecraft
+    // @base ElementTag
+    // @format
+    // The identity format for ViveCraftPlayerTag is <uuid>
+    // For example, 'vivecraft@1234-1234-1234'.
+    //
+    // @plugin Depenizen, ViveCraft
+    // @description
+    // A ViveCraftPlayerTag represents a player who uses ViveCraft.
+    //
+    // -->
+
+    public static ViveCraftPlayerTag valueOf(String uuid) {
+        return valueOf(uuid, null);
+    }
+
+    @Fetchable("vivecraft")
+    public static ViveCraftPlayerTag valueOf(String string, TagContext context) {
+        if (string == null) {
+            return null;
+        }
+        try {
+            string = string.replace("vivecraft@", "");
+            UUID uuid = UUID.fromString(string);
+            PlayerTag player = new PlayerTag(uuid);
+            if (!ViveCraftBridge.isViveCraftPlayer(player.getPlayerEntity())) {
+                return null;
+            }
+            return new ViveCraftPlayerTag(player.getPlayerEntity());
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static boolean matches(String string) {
+        return string.startsWith("vivecraft@");
+    }
+
+    public ViveCraftPlayerTag(Player player) {
+        if (VSE.isVive(player)) {
+            this.vivePlayer = ViveCraftBridge.getViveCraftPlayer(player);
+            this.player = player;
+        }
+        else {
+            Debug.echoError("ViceCraftPlayer referenced is null!");
+        }
+    }
+
+    public VivePlayer getVivePlayer() {
+        return vivePlayer;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public Player player;
+
+    public VivePlayer vivePlayer;
+
+    private String prefix;
+
+    @Override
+    public ObjectTag getObjectAttribute(Attribute attribute) {
+        return tagProcessor.getObjectAttribute(this, attribute);
+    }
+
+    @Override
+    public String getPrefix() {
+        return prefix;
+    }
+
+    @Override
+    public boolean isUnique() {
+        return true;
+    }
+
+    @Override
+    public String identify() {
+        return "vivecraft@" + player.getUniqueId();
+    }
+
+    @Override
+    public String identifySimple() {
+        return identify();
+    }
+
+    @Override
+    public String toString() { return identify();}
+
+    @Override
+    public ObjectTag setPrefix(String prefix) {
+        this.prefix = prefix;
+        return this;
+    }
+
+    public static ObjectTagProcessor<ViveCraftPlayerTag> tagProcessor = new ObjectTagProcessor<>();
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <ViveCraftPlayerTag.activehand>
+        // @returns ElementTag
+        // @description
+        // Returns the active hand of the ViveCraftPlayer. Can be right or left.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "activehand", (attribute, object) -> {
+            return new ElementTag(object.getPlayer().getMetadata("activehand").get(0).asString());
+        });
+
+        // <--[tag]
+        // @attribute <ViveCraftPlayerTag.is_seated>
+        // @returns ElementTag(Boolean)
+        // @description
+        // Returns whether the ViveCraftPlayer sits or not.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "is_seated", (attribute, object) -> {
+            return new ElementTag(object.getPlayer().getMetadata("seated").get(0).asBoolean());
+        });
+
+        // <--[tag]
+        // @attribute <ViveCraftPlayerTag.position[head/left/right]>
+        // @returns LocationTag
+        // @description
+        // Returns a LocationTag of the given position.
+        // -->
+        tagProcessor.registerTag(LocationTag.class, "position", (attribute, object) -> {
+            if (!attribute.hasParam()) {
+                attribute.echoError("ViveCraftPlayer.position[...] tag must have an input.");
+                return null;
+            }
+            Location location;
+            ElementTag type = attribute.paramAsType(ElementTag.class);
+            switch (type.toString()) {
+                case "head":
+                    location = (Location) object.getPlayer().getMetadata("head.pos").get(0).value();
+                    break;
+                case "left":
+                    location = (Location) object.getPlayer().getMetadata("lefthand.pos").get(0).value();
+                    break;
+                case "right":
+                    location = (Location) object.getPlayer().getMetadata("righthand.pos").get(0).value();
+                    break;
+                default:
+                    attribute.echoError("Attribute must be 'head', 'left' or 'right'");
+                    return null;
+            }
+            if (location == null) {
+                attribute.echoError("Location is not valid. Did a plugin overwrote the data?");
+                return null;
+            }
+            return new LocationTag(location);
+        });
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/vivecraft/ViveCraftPlayerTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/vivecraft/ViveCraftPlayerTag.java
@@ -24,12 +24,11 @@ public class ViveCraftPlayerTag implements ObjectTag {
     // @prefix vivecraft
     // @base ElementTag
     // @format
-    // The identity format for ViveCraftPlayerTag is <uuid>
-    // For example, 'vivecraft@1234-1234-1234'.
+    // The identity format for ViveCraftPlayerTag is the UUID of the relevant player.
     //
     // @plugin Depenizen, ViveCraft
     // @description
-    // A ViveCraftPlayerTag represents a player who uses ViveCraft.
+    // A ViveCraftPlayerTag represents a player which is in VR.
     //
     // -->
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/vivecraft/ViveCraftPlayerTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/vivecraft/ViveCraftPlayerTag.java
@@ -122,12 +122,12 @@ public class ViveCraftPlayerTag implements ObjectTag {
     public static void registerTags() {
 
         // <--[tag]
-        // @attribute <ViveCraftPlayerTag.activehand>
+        // @attribute <ViveCraftPlayerTag.active_hand>
         // @returns ElementTag
         // @description
         // Returns the active hand of the ViveCraftPlayer. Can be right or left.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "activehand", (attribute, object) -> {
+        tagProcessor.registerTag(ElementTag.class, "active_hand", (attribute, object) -> {
             return new ElementTag(object.getPlayer().getMetadata("activehand").get(0).asString());
         });
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/vivecraft/ViveCraftPlayerTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/vivecraft/ViveCraftPlayerTag.java
@@ -125,7 +125,7 @@ public class ViveCraftPlayerTag implements ObjectTag {
         // @attribute <ViveCraftPlayerTag.active_hand>
         // @returns ElementTag
         // @description
-        // Returns the active hand of the ViveCraftPlayer. Can be right or left.
+        // Returns the active hand of the ViveCraftPlayer. Returns either right or left.
         // -->
         tagProcessor.registerTag(ElementTag.class, "active_hand", (attribute, object) -> {
             return new ElementTag(object.getPlayer().getMetadata("activehand").get(0).asString());

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/vivecraft/ViveCraftPlayerProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/vivecraft/ViveCraftPlayerProperties.java
@@ -1,0 +1,73 @@
+package com.denizenscript.depenizen.bukkit.properties.vivecraft;
+
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.Property;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.denizenscript.depenizen.bukkit.objects.vivecraft.ViveCraftPlayerTag;
+import org.vivecraft.VSE;
+
+public class ViveCraftPlayerProperties implements Property {
+
+    @Override
+    public String getPropertyString() {
+        return null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "ViveCraftPlayer";
+    }
+
+    public static boolean describes(ObjectTag object) {
+        return object instanceof PlayerTag;
+    }
+
+    public static ViveCraftPlayerProperties getFrom(ObjectTag object) {
+        if (!describes(object)) {
+            return null;
+        }
+        else {
+            return new ViveCraftPlayerProperties((PlayerTag) object);
+        }
+    }
+
+    public static final String[] handledMechs = new String[] {
+    }; // None
+
+    private ViveCraftPlayerProperties(PlayerTag player) {
+        this.player = player;
+    }
+
+    PlayerTag player;
+
+
+    public static void registerTags() {
+
+        // <--[tag]
+        // @attribute <PlayerTag.is_vivecraft>
+        // @returns ElementTag(Boolean)
+        // @plugin Depenizen, ViveCraft
+        // @description
+        // Returns whether the player is running on VR.
+        // -->
+
+        PropertyParser.registerTag(ViveCraftPlayerProperties.class, ElementTag.class,"is_vivecraft", (attribute, object) -> {
+            return new ElementTag(VSE.isVive(object.player.getPlayerEntity()));
+        });
+
+        // <--[tag]
+        // @attribute <PlayerTag.vivecraft>
+        // @returns ViveCraftPlayerTag
+        // @plugin Depenizen, ViveCraft
+        // @description
+        // Returns the ViveCraftPlayer for this player.
+        // -->
+
+        PropertyParser.registerTag(ViveCraftPlayerProperties.class, ViveCraftPlayerTag.class, "vivecraft", (attribute, object) -> {
+            return new ViveCraftPlayerTag(object.player.getPlayerEntity());
+        });
+
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/vivecraft/ViveCraftPlayerProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/vivecraft/ViveCraftPlayerProperties.java
@@ -1,49 +1,13 @@
 package com.denizenscript.depenizen.bukkit.properties.vivecraft;
 
 import com.denizenscript.denizen.objects.PlayerTag;
-import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.depenizen.bukkit.objects.vivecraft.ViveCraftPlayerTag;
 import org.vivecraft.VSE;
 
-public class ViveCraftPlayerProperties implements Property {
+public class ViveCraftPlayerProperties {
 
-    @Override
-    public String getPropertyString() {
-        return null;
-    }
-
-    @Override
-    public String getPropertyId() {
-        return "ViveCraftPlayer";
-    }
-
-    public static boolean describes(ObjectTag object) {
-        return object instanceof PlayerTag;
-    }
-
-    public static ViveCraftPlayerProperties getFrom(ObjectTag object) {
-        if (!describes(object)) {
-            return null;
-        }
-        else {
-            return new ViveCraftPlayerProperties((PlayerTag) object);
-        }
-    }
-
-    public static final String[] handledMechs = new String[] {
-    }; // None
-
-    private ViveCraftPlayerProperties(PlayerTag player) {
-        this.player = player;
-    }
-
-    PlayerTag player;
-
-
-    public static void registerTags() {
+    public static void register() {
 
         // <--[tag]
         // @attribute <PlayerTag.is_vivecraft>
@@ -52,8 +16,8 @@ public class ViveCraftPlayerProperties implements Property {
         // @description
         // Returns whether the player is running on VR or not.
         // -->
-        PropertyParser.registerTag(ViveCraftPlayerProperties.class, ElementTag.class,"is_vivecraft", (attribute, object) -> {
-            return new ElementTag(VSE.isVive(object.player.getPlayerEntity()));
+        PlayerTag.registerOnlineOnlyTag(ElementTag.class,"is_vivecraft", (attribute, object) -> {
+            return new ElementTag(VSE.isVive(object.getPlayerEntity()));
         });
 
         // <--[tag]
@@ -63,8 +27,8 @@ public class ViveCraftPlayerProperties implements Property {
         // @description
         // Returns the ViveCraftPlayerTag for this player.
         // -->
-        PropertyParser.registerTag(ViveCraftPlayerProperties.class, ViveCraftPlayerTag.class, "vivecraft", (attribute, object) -> {
-            return new ViveCraftPlayerTag(object.player.getPlayerEntity());
+        PlayerTag.registerOnlineOnlyTag(ViveCraftPlayerTag.class, "vivecraft", (attribute, object) -> {
+            return new ViveCraftPlayerTag(object.getPlayerEntity());
         });
 
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/vivecraft/ViveCraftPlayerProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/vivecraft/ViveCraftPlayerProperties.java
@@ -52,7 +52,6 @@ public class ViveCraftPlayerProperties implements Property {
         // @description
         // Returns whether the player is running on VR or not.
         // -->
-
         PropertyParser.registerTag(ViveCraftPlayerProperties.class, ElementTag.class,"is_vivecraft", (attribute, object) -> {
             return new ElementTag(VSE.isVive(object.player.getPlayerEntity()));
         });
@@ -64,7 +63,6 @@ public class ViveCraftPlayerProperties implements Property {
         // @description
         // Returns the ViveCraftPlayerTag for this player.
         // -->
-
         PropertyParser.registerTag(ViveCraftPlayerProperties.class, ViveCraftPlayerTag.class, "vivecraft", (attribute, object) -> {
             return new ViveCraftPlayerTag(object.player.getPlayerEntity());
         });

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/vivecraft/ViveCraftPlayerProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/vivecraft/ViveCraftPlayerProperties.java
@@ -50,7 +50,7 @@ public class ViveCraftPlayerProperties implements Property {
         // @returns ElementTag(Boolean)
         // @plugin Depenizen, ViveCraft
         // @description
-        // Returns whether the player is running on VR.
+        // Returns whether the player is running on VR or not.
         // -->
 
         PropertyParser.registerTag(ViveCraftPlayerProperties.class, ElementTag.class,"is_vivecraft", (attribute, object) -> {
@@ -62,7 +62,7 @@ public class ViveCraftPlayerProperties implements Property {
         // @returns ViveCraftPlayerTag
         // @plugin Depenizen, ViveCraft
         // @description
-        // Returns the ViveCraftPlayer for this player.
+        // Returns the ViveCraftPlayerTag for this player.
         // -->
 
         PropertyParser.registerTag(ViveCraftPlayerProperties.class, ViveCraftPlayerTag.class, "vivecraft", (attribute, object) -> {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -45,6 +45,7 @@ softdepend:
     - TownyChat
     - Vampire
     - ViaVersion
+    - Vivecraft-Spigot-Extensions
     - Votifier
     - WorldEdit
     - WorldGuard


### PR DESCRIPTION
This PR adds the following additions:

Objects:
`ViveCraftPlayerTag` which represents a player which uses VR.

Commands:
`vivemirror` which mirrors a viveplayers pose to a npc.
Syntax: `vivemirror [<npc>] [mirror:<vivecraftplayer>] (targets:{player}/<player>|...)`

Tags:
`PlayerTag.is_vivecraft` - which returns whether the player is running on VR or not.
`PlayerTag.vivecraft` - returns the ViveCraftPlayerTag for this player.
`ViveCraftPlayerTag.active_hand` - returns the active hand of the ViveCraftPlayer. Returns either right or left.
`ViveCraftPlayerTag.is_seated` - returns whether the ViveCraftPlayer sits or not.
`ViveCraftPlayerTag.position[head/left/right]` - returns a LocationTag of the given position.