### PR TITLE
Bungee execute as player

### DIFF
--- a/src/main/java/com/denizenscript/depenizen/bukkit/bungee/packets/out/ExecuteCommandPacketOut.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bungee/packets/out/ExecuteCommandPacketOut.java
@@ -3,13 +3,17 @@ package com.denizenscript.depenizen.bukkit.bungee.packets.out;
 import com.denizenscript.depenizen.bukkit.bungee.PacketOut;
 import io.netty.buffer.ByteBuf;
 
+import java.util.UUID;
+
 public class ExecuteCommandPacketOut extends PacketOut {
 
-    public ExecuteCommandPacketOut(String command) {
+    public ExecuteCommandPacketOut(String command, UUID executingPlayer) {
         this.command = command;
+        this.executingPlayer = executingPlayer;
     }
 
     public String command;
+    public UUID executingPlayer;
 
     @Override
     public int getPacketId() {
@@ -19,5 +23,9 @@ public class ExecuteCommandPacketOut extends PacketOut {
     @Override
     public void writeTo(ByteBuf buf) {
         writeString(buf, command);
+        if (executingPlayer != null) {
+            buf.writeLong(executingPlayer.getMostSignificantBits());
+            buf.writeLong(executingPlayer.getLeastSignificantBits());
+        }
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/bungee/BungeeExecuteCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/bungee/BungeeExecuteCommand.java
@@ -33,8 +33,8 @@ public class BungeeExecuteCommand extends AbstractCommand {
     // @Short Runs a command on the Bungee proxy server.
     //
     // @Description
-    // Runs a command on the Bungee proxy server.
-    // The command is run as the server by default, use 'as_player' to run the command as the linked player.
+    // Runs a command on the Bungee proxy server, works similarly to <@link command execute>.
+    // The command is run as the server by default, use 'as_player' to run it as the linked player.
     //
     // @Tags
     // None

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/bungee/BungeeExecuteCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/bungee/BungeeExecuteCommand.java
@@ -62,7 +62,7 @@ public class BungeeExecuteCommand extends AbstractCommand {
             case AS_PLAYER -> {
                 PlayerTag player = Utilities.getEntryPlayer(scriptEntry);
                 if (player == null) {
-                    throw new InvalidArgumentsRuntimeException("Must have a linked player to use 'as_player'.");
+                    throw new InvalidArgumentsRuntimeException("Must have a linked player to execute 'as_player'.");
                 }
                 yield new ExecuteCommandPacketOut(command.asString(), player.getUUID());
             }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/bungee/BungeeExecuteCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/bungee/BungeeExecuteCommand.java
@@ -34,13 +34,13 @@ public class BungeeExecuteCommand extends AbstractCommand {
     //
     // @Description
     // Runs a command on the Bungee proxy server, works similarly to <@link command execute>.
-    // The command is run as the server by default, use 'as_player' to run it as the linked player.
+    // The command is run as the proxy by default, use 'as_player' to run it as the linked player.
     //
     // @Tags
     // None
     //
     // @Usage
-    // Use to run the 'alert' bungee command as the server.
+    // Use to run the 'alert' bungee command as the proxy.
     // - bungeeexecute "alert Network restart in 5 minutes..."
     // @Usage
     // Use to run the 'perms' bungee command as the linked player.


### PR DESCRIPTION
## Additions

- Adds `as_server/player` to `bungeeexecute`, to execute player proxy commands.
- `ExecuteCommandPacketOut` now optionally has a UUID (2 longs), for executing as a player.

## Changes

- Updated `bungeeexecute` to modern command handling/format.

## Notes

- See https://github.com/DenizenScript/DepenizenBungee/pull/5