### PR TITLE
Jobs integration cleanup & fixes

### DIFF
--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/JobsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/JobsBridge.java
@@ -12,7 +12,7 @@ import com.denizenscript.depenizen.bukkit.Bridge;
 import com.denizenscript.depenizen.bukkit.commands.jobs.JobsCommand;
 import com.denizenscript.depenizen.bukkit.events.jobs.*;
 import com.denizenscript.depenizen.bukkit.objects.jobs.JobsJobTag;
-import com.denizenscript.depenizen.bukkit.properties.jobs.JobsPlayerProperties;
+import com.denizenscript.depenizen.bukkit.properties.jobs.JobsPlayerExtensions;
 import com.gamingmesh.jobs.Jobs;
 
 public class JobsBridge extends Bridge {
@@ -32,7 +32,7 @@ public class JobsBridge extends Bridge {
         ScriptEvent.registerScriptEvent(JobsJobsLevelUpScriptEvent.class);
         ObjectFetcher.registerWithObjectFetcher(JobsJobTag.class, JobsJobTag.tagProcessor);
         DenizenCore.commandRegistry.registerCommand(JobsCommand.class);
-        JobsPlayerProperties.register();
+        JobsPlayerExtensions.register();
 
         // <--[tag]
         // @attribute <jobs>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/JobsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/JobsBridge.java
@@ -2,24 +2,26 @@ package com.denizenscript.depenizen.bukkit.bridges;
 
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.events.ScriptEvent;
+import com.denizenscript.denizencore.objects.ObjectFetcher;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.tags.TagManager;
 import com.denizenscript.denizencore.utilities.debugging.SlowWarning;
-import com.denizenscript.depenizen.bukkit.events.jobs.*;
+import com.denizenscript.denizencore.utilities.debugging.Warning;
 import com.denizenscript.depenizen.bukkit.Bridge;
 import com.denizenscript.depenizen.bukkit.commands.jobs.JobsCommand;
+import com.denizenscript.depenizen.bukkit.events.jobs.*;
 import com.denizenscript.depenizen.bukkit.objects.jobs.JobsJobTag;
-import com.gamingmesh.jobs.Jobs;
-import com.gamingmesh.jobs.container.Job;
-import com.denizenscript.denizen.objects.PlayerTag;
-import com.denizenscript.denizencore.objects.ObjectFetcher;
-import com.denizenscript.denizencore.objects.core.ListTag;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.depenizen.bukkit.properties.jobs.JobsPlayerProperties;
-import com.denizenscript.denizencore.tags.TagManager;
+import com.gamingmesh.jobs.Jobs;
 
 public class JobsBridge extends Bridge {
 
-    public static SlowWarning deprecatedJobsConstructor = new SlowWarning("jobsDeprecatedConstructor", "The 'jobs' constructor from Depenizen/Jobs is deprecated: use 'jobs_job'");
+    public static Warning jobsDeprecatedConstructor = new SlowWarning("jobsDeprecatedConstructor", "The 'jobs' constructor from Depenizen/Jobs is deprecated: use 'jobs_job'");
+    public static Warning jobsNameShort = new SlowWarning("jobsNameShort", "The tag 'JobsJobTag.name.short' from Depenizen/Jobs is deprecated: use 'JobsJobTag.short_name'");
+    public static Warning jobsXpLevel = new SlowWarning("jobsXpLevel", "The tag 'JobsJobTag.xp.level' from Depenizen/Jobs is deprecated: use 'JobsJobTag.level'");
+    public static Warning jobsXpMax = new SlowWarning("jobsXpMax", "The tag 'JobsJobTag.xp.max' from Depenizen/Jobs is deprecated: use 'JobsJobTag.max_xp'");
+    public static Warning jobsSingleLineDescription = new SlowWarning("jobsSingleLineDescription", "'JobsJobTag.description' is deprecated, as single-line descriptions are deprecated in Jobs. Use 'JobsJobTag.full_description' instead.");
 
     @Override
     public void init() {
@@ -29,7 +31,8 @@ public class JobsBridge extends Bridge {
         ScriptEvent.registerScriptEvent(JobsJobsLeaveScriptEvent.class);
         ScriptEvent.registerScriptEvent(JobsJobsLevelUpScriptEvent.class);
         ObjectFetcher.registerWithObjectFetcher(JobsJobTag.class, JobsJobTag.tagProcessor);
-        PropertyParser.registerProperty(JobsPlayerProperties.class, PlayerTag.class);
+        DenizenCore.commandRegistry.registerCommand(JobsCommand.class);
+        JobsPlayerProperties.register();
 
         // <--[tag]
         // @attribute <jobs>
@@ -40,14 +43,10 @@ public class JobsBridge extends Bridge {
         // -->
         TagManager.registerTagHandler(ObjectTag.class, "jobs", (attribute) -> {
             if (attribute.hasParam()) {
-                deprecatedJobsConstructor.warn(attribute.context);
+                jobsDeprecatedConstructor.warn(attribute.context);
                 return JobsJobTag.valueOf(attribute.getParam(), attribute.context);
             }
-            ListTag jobsList = new ListTag();
-            for (Job job : Jobs.getJobs()) {
-                jobsList.addObject(new JobsJobTag(job));
-            }
-            return jobsList;
+            return new ListTag(Jobs.getJobs(), JobsJobTag::new);
         });
 
         // <--[tag]
@@ -57,12 +56,6 @@ public class JobsBridge extends Bridge {
         // @description
         // Returns the job tag with the given name.
         // -->
-        TagManager.registerTagHandler(JobsJobTag.class, "jobs_job", attribute -> {
-            if (attribute.hasParam()) {
-                return JobsJobTag.valueOf(attribute.getParam(), attribute.context);
-            }
-            return null;
-        });
-        DenizenCore.commandRegistry.registerCommand(JobsCommand.class);
+        TagManager.registerTagHandler(JobsJobTag.class, JobsJobTag.class, "jobs_job", (attribute, param) -> param);
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/jobs/JobsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/jobs/JobsCommand.java
@@ -1,14 +1,20 @@
 package com.denizenscript.depenizen.bukkit.commands.jobs;
 
-import com.denizenscript.denizencore.objects.Argument;
-import com.gamingmesh.jobs.Jobs;
-import com.gamingmesh.jobs.container.JobsPlayer;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
+import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgDefaultNull;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgLinear;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
+import com.denizenscript.denizencore.utilities.Deprecations;
 import com.denizenscript.depenizen.bukkit.objects.jobs.JobsJobTag;
+import com.gamingmesh.jobs.Jobs;
+import com.gamingmesh.jobs.PlayerManager;
+import com.gamingmesh.jobs.container.Job;
+import com.gamingmesh.jobs.container.JobsPlayer;
 
 public class JobsCommand extends AbstractCommand {
 
@@ -16,6 +22,7 @@ public class JobsCommand extends AbstractCommand {
         setName("jobs");
         setSyntax("jobs [promote/demote/join/quit] [<job>] (<#>)");
         setRequiredArguments(2, 3);
+        autoCompile();
     }
 
     // <--[command]
@@ -28,8 +35,8 @@ public class JobsCommand extends AbstractCommand {
     // @Short Modifies the specified job of a player.
     //
     // @Description
-    // This allows you to promote or demote a player's job level. This also allows you
-    // to force a player to join or quit a job.
+    // This allows you to promote or demote a player's job level.
+    // This also allows you to force a player to join or quit a job.
     //
     // @Tags
     // <PlayerTag.job[<job>]>
@@ -49,64 +56,44 @@ public class JobsCommand extends AbstractCommand {
     //
     // -->
 
-    private enum Action {PROMOTE, DEMOTE, JOIN, QUIT}
 
     @Override
-    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
-
-        for (Argument arg : scriptEntry) {
-            if (!scriptEntry.hasObject("action")
-                    && arg.matchesEnum(Action.class)) {
-                scriptEntry.addObject("action", Action.valueOf(arg.getValue().toUpperCase()));
-            }
-            else if (!scriptEntry.hasObject("job")
-                    && arg.matchesArgumentType(JobsJobTag.class)) {
-                scriptEntry.addObject("job", JobsJobTag.valueOf(arg.getValue(), scriptEntry.context));
-            }
-            else if (!scriptEntry.hasObject("number")
-                    && arg.matchesInteger()) {
-                scriptEntry.addObject("number", new ElementTag(arg.getValue()));
-            }
+    public void addCustomTabCompletions(TabCompletionsBuilder tab) {
+        for (Job job : Jobs.getJobs()) {
+            tab.add(job.getName());
         }
-
-        if (!scriptEntry.hasObject("action")) {
-            throw new InvalidArgumentsException("Must specify an action!");
-        }
-        if (!scriptEntry.hasObject("job")) {
-            throw new InvalidArgumentsException("Must specify a job!");
-        }
-        if (!Utilities.entryHasPlayer(scriptEntry)) {
-            throw new InvalidArgumentsException("Must have a player attached to the queue.");
-        }
-
     }
 
-    @Override
-    public void execute(ScriptEntry scriptEntry) {
+    public enum Action {PROMOTE, DEMOTE, JOIN, QUIT}
 
-        Action action = (Action) scriptEntry.getObject("action");
-        JobsJobTag job = scriptEntry.getObjectTag("job");
-        int number = (scriptEntry.hasObject("number") ? scriptEntry.getElement("number").asInt() : 0);
-        JobsPlayer player = Jobs.getPlayerManager().getJobsPlayer(Utilities.getEntryPlayer(scriptEntry).getName());
-
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("action") Action action,
+                                   @ArgLinear @ArgName("job") ObjectTag jobObject,
+                                   @ArgLinear @ArgDefaultNull @ArgName("number") ObjectTag numberObject) {
+        if (!Utilities.entryHasPlayer(scriptEntry)) {
+            throw new InvalidArgumentsRuntimeException("Missing linked player.");
+        }
+        if (numberObject != null && jobObject.asElement().isInt()) {
+            Deprecations.outOfOrderArgs.warn(scriptEntry);
+            ObjectTag jobObjectSwitch = jobObject;
+            jobObject = numberObject;
+            numberObject = jobObjectSwitch;
+        }
+        ElementTag numberElement = numberObject != null ? numberObject.asElement() : new ElementTag(0);
+        if (!numberElement.isInt()) {
+            throw new InvalidArgumentsRuntimeException("Invalid number '" + numberElement + "' specified: must be a valid non-decimal number.");
+        }
+        JobsJobTag job = jobObject.asType(JobsJobTag.class, scriptEntry.context);
+        if (job == null) {
+            throw new InvalidArgumentsRuntimeException("Invalid JobsJobTag specified: " + jobObject + '.');
+        }
+        PlayerManager playerManager = Jobs.getPlayerManager();
+        JobsPlayer player = playerManager.getJobsPlayer(Utilities.getEntryPlayer(scriptEntry).getUUID());
         switch (action) {
-
-            case PROMOTE:
-                player.promoteJob(job.getJob(), number);
-                break;
-
-            case DEMOTE:
-                player.demoteJob(job.getJob(), number);
-                break;
-
-            case JOIN:
-                player.joinJob(job.getJob());
-                break;
-
-            case QUIT:
-                player.leaveJob(job.getJob());
-                break;
-
+            case PROMOTE -> playerManager.promoteJob(player, job.getJob(), numberElement.asInt());
+            case DEMOTE -> playerManager.demoteJob(player, job.getJob(), numberElement.asInt());
+            case JOIN -> playerManager.joinJob(player, job.getJob());
+            case QUIT -> playerManager.leaveJob(player, job.getJob());
         }
 
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/jobs/JobsJobsExpGainScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/jobs/JobsJobsExpGainScriptEvent.java
@@ -3,11 +3,9 @@ package com.denizenscript.depenizen.bukkit.events.jobs;
 import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
-import com.denizenscript.denizencore.events.ScriptEvent;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.depenizen.bukkit.objects.jobs.JobsJobTag;
 import com.gamingmesh.jobs.Jobs;
 import com.gamingmesh.jobs.api.JobsExpGainEvent;
@@ -27,9 +25,9 @@ public class JobsJobsExpGainScriptEvent extends BukkitScriptEvent implements Lis
     // @Triggers when a player performs an action that would cause them to earn Jobs exp for a certain job.
     //
     // @Context
-    // <context.job> Returns the job that the player is gaining exp for.
-    // <context.experience> Returns the amount of exp the player will earn.
-    // <context.action> Returns the name of the action being paid for, which can be any of the strings from: <@link url https://github.com/Zrips/Jobs/blob/master/src/main/java/com/gamingmesh/jobs/container/ActionType.java>.
+    // <context.job> Returns a JobsJobTag of the job that the player is gaining exp for.
+    // <context.experience> Returns an ElementTag(Decimal) of the amount of exp the player will earn.
+    // <context.action> Returns an ElementTag of the name of the action being paid for, which can be any of the strings from: <@link url https://github.com/Zrips/Jobs/blob/master/src/main/java/com/gamingmesh/jobs/container/ActionType.java>.
     //
     // @Determine
     // "EXP:<ElementTag(Decimal)>" to change the amount of Jobs exp this action should provide.
@@ -45,6 +43,13 @@ public class JobsJobsExpGainScriptEvent extends BukkitScriptEvent implements Lis
     public JobsJobsExpGainScriptEvent() {
         registerCouldMatcher("jobs player earns exp for <'job'>");
         registerSwitches("action");
+        this.<JobsJobsExpGainScriptEvent, ElementTag>registerOptionalDetermination("exp", ElementTag.class, (evt, context, determination) -> {
+            if (determination.isDouble()) {
+                evt.event.setExp(determination.asDouble());
+                return true;
+            }
+            return false;
+        });
     }
 
     public JobsExpGainEvent event;
@@ -52,8 +57,7 @@ public class JobsJobsExpGainScriptEvent extends BukkitScriptEvent implements Lis
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.eventArgLowerAt(5).equals("job")
-            && !runGenericCheck(path.eventArgAt(5), job.getJob().getName())) {
+        if (!path.tryArgObject(5, job)) {
             return false;
         }
         if (!runGenericSwitchCheck(path, "action", event.getActionInfo().getType().getName())) {
@@ -64,34 +68,17 @@ public class JobsJobsExpGainScriptEvent extends BukkitScriptEvent implements Lis
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "job":
-                return job;
-            case "experience":
-                return new ElementTag(event.getExp());
-            case "action":
-                return new ElementTag(event.getActionInfo().getType().getName());
-            default:
-                return super.getContext(name);
-        }
+        return switch (name) {
+            case "job" -> job;
+            case "experience" -> new ElementTag(event.getExp());
+            case "action" -> new ElementTag(event.getActionInfo().getType().getName(), true);
+            default -> super.getContext(name);
+        };
     }
 
     @Override
     public ScriptEntryData getScriptEntryData() {
         return new BukkitScriptEntryData(new PlayerTag(event.getPlayer()), null);
-    }
-
-    @Override
-    public boolean applyDetermination(ScriptEvent.ScriptPath path, ObjectTag determinationObj) {
-        if (determinationObj instanceof ElementTag) {
-            String determination = determinationObj.toString();
-            String lower = CoreUtilities.toLowerCase(determination);
-            if (lower.startsWith("exp:")) {
-                event.setExp(Double.parseDouble(determination.substring("exp:".length())));
-                return true;
-            }
-        }
-        return super.applyDetermination(path, determinationObj);
     }
 
     @EventHandler

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/jobs/JobsJobsJoinScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/jobs/JobsJobsJoinScriptEvent.java
@@ -40,8 +40,7 @@ public class JobsJobsJoinScriptEvent extends BukkitScriptEvent implements Listen
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.eventArgLowerAt(3).equals("job")
-                && !runGenericCheck(path.eventArgAt(3), job.getJob().getName())) {
+        if (!path.tryArgObject(3, job)) {
             return false;
         }
         return super.matches(path);
@@ -49,12 +48,10 @@ public class JobsJobsJoinScriptEvent extends BukkitScriptEvent implements Listen
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "job":
-                return job;
-            default:
-                return super.getContext(name);
-        }
+        return switch (name) {
+            case "job" -> job;
+            default -> super.getContext(name);
+        };
     }
 
     @Override

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/jobs/JobsJobsLeaveScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/jobs/JobsJobsLeaveScriptEvent.java
@@ -40,8 +40,7 @@ public class JobsJobsLeaveScriptEvent extends BukkitScriptEvent implements Liste
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.eventArgLowerAt(3).equals("job")
-                && !runGenericCheck(path.eventArgAt(3), job.getJob().getName())) {
+        if (!path.tryArgObject(3, job)) {
             return false;
         }
         return super.matches(path);
@@ -49,12 +48,10 @@ public class JobsJobsLeaveScriptEvent extends BukkitScriptEvent implements Liste
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "job":
-                return job;
-            default:
-                return super.getContext(name);
-        }
+        return switch (name) {
+            case "job" -> job;
+            default -> super.getContext(name);
+        };
     }
 
     @Override

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/jobs/JobsJobsLevelUpScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/jobs/JobsJobsLevelUpScriptEvent.java
@@ -40,8 +40,7 @@ public class JobsJobsLevelUpScriptEvent extends BukkitScriptEvent implements Lis
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.eventArgLowerAt(4).equals("job")
-                && !runGenericCheck(path.eventArgAt(4), job.getJob().getName())) {
+        if (!path.tryArgObject(4, job)) {
             return false;
         }
         return super.matches(path);
@@ -49,12 +48,10 @@ public class JobsJobsLevelUpScriptEvent extends BukkitScriptEvent implements Lis
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "job":
-                return job;
-            default:
-                return super.getContext(name);
-        }
+        return switch (name) {
+            case "job" -> job;
+            default -> super.getContext(name);
+        };
     }
 
     @Override

--- a/src/main/java/com/denizenscript/depenizen/bukkit/events/jobs/JobsJobsPaymentScriptEvent.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/events/jobs/JobsJobsPaymentScriptEvent.java
@@ -6,7 +6,6 @@ import com.denizenscript.denizen.utilities.implementation.BukkitScriptEntryData;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntryData;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.depenizen.bukkit.objects.jobs.JobsJobTag;
 import com.gamingmesh.jobs.Jobs;
 import com.gamingmesh.jobs.api.JobsPrePaymentEvent;
@@ -26,10 +25,10 @@ public class JobsJobsPaymentScriptEvent extends BukkitScriptEvent implements Lis
     // @Triggers when a player performs an action that would cause them to be paid for a certain job.
     //
     // @Context
-    // <context.job> Returns the job that the player is being paid for.
-    // <context.money> Returns the amount of money the player will be paid.
-    // <context.points> Returns the amount of points the player will be paid.
-    // <context.action> Returns the name of the action being paid for, which can be any of the strings from: <@link url https://github.com/Zrips/Jobs/blob/master/src/main/java/com/gamingmesh/jobs/container/ActionType.java>.
+    // <context.job> Returns an JobsJobTag of the job that the player is being paid for.
+    // <context.money> Returns an ElementTag(Decimal) of the amount of money the player will be paid.
+    // <context.points> Returns an ElementTag(Decimal) of the amount of points the player will be paid.
+    // <context.action> Returns an ElementTag the name of the action being paid for, which can be any of the strings from: <@link url https://github.com/Zrips/Jobs/blob/master/src/main/java/com/gamingmesh/jobs/container/ActionType.java>.
     //
     // @Determine
     // "MONEY:<ElementTag(Decimal)>" to change the amount of money this action should provide.
@@ -46,6 +45,20 @@ public class JobsJobsPaymentScriptEvent extends BukkitScriptEvent implements Lis
     public JobsJobsPaymentScriptEvent() {
         registerCouldMatcher("jobs player earns money for <'job'>");
         registerSwitches("action");
+        this.<JobsJobsPaymentScriptEvent, ElementTag>registerOptionalDetermination("money", ElementTag.class, (evt, context, input) -> {
+            if (input.isDouble()) {
+                evt.event.setAmount(input.asDouble());
+                return true;
+            }
+            return false;
+        });
+        this.<JobsJobsPaymentScriptEvent, ElementTag>registerOptionalDetermination("points", ElementTag.class, (evt, context, input) -> {
+            if (input.isDouble()) {
+                evt.event.setPoints(input.asDouble());
+                return true;
+            }
+            return false;
+        });
     }
 
     public JobsPrePaymentEvent event;
@@ -53,8 +66,7 @@ public class JobsJobsPaymentScriptEvent extends BukkitScriptEvent implements Lis
 
     @Override
     public boolean matches(ScriptPath path) {
-        if (!path.eventArgLowerAt(5).equals("job")
-                && !runGenericCheck(path.eventArgAt(4), job.getJob().getName())) {
+        if (!path.tryArgObject(5, job)) {
             return false;
         }
         if (!runGenericSwitchCheck(path, "action", event.getActionInfo().getType().getName())) {
@@ -65,39 +77,18 @@ public class JobsJobsPaymentScriptEvent extends BukkitScriptEvent implements Lis
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "job":
-                return job;
-            case "money":
-                return new ElementTag(event.getAmount());
-            case "points":
-                return new ElementTag(event.getPoints());
-            case "action":
-                return new ElementTag(event.getActionInfo().getType().getName());
-            default:
-                return super.getContext(name);
-        }
+        return switch (name) {
+            case "job" -> job;
+            case "money" -> new ElementTag(event.getAmount());
+            case "points" -> new ElementTag(event.getPoints());
+            case "action" -> new ElementTag(event.getActionInfo().getType().getName(), true);
+            default -> super.getContext(name);
+        };
     }
 
     @Override
     public ScriptEntryData getScriptEntryData() {
         return new BukkitScriptEntryData(new PlayerTag(event.getPlayer()), null);
-    }
-
-    @Override
-    public boolean applyDetermination(ScriptPath path, ObjectTag determinationObj) {
-        if (determinationObj instanceof ElementTag) {
-            String determination = determinationObj.toString();
-            String lower = CoreUtilities.toLowerCase(determination);
-            if (lower.startsWith("money:")) {
-                event.setAmount(Double.parseDouble(determination.substring("money:".length())));
-                return true;
-            } else if (lower.startsWith("points:")) {
-                event.setPoints(Double.parseDouble(determination.substring("points:".length())));
-                return true;
-            }
-        }
-        return super.applyDetermination(path, determinationObj);
     }
 
     @EventHandler

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/jobs/JobsJobTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/jobs/JobsJobTag.java
@@ -30,7 +30,7 @@ public class JobsJobTag implements ObjectTag, Adjustable {
     // @base ElementTag
     // @format
     // The identity format for jobs is the player UUID (optional), followed by the job name
-    // For example: job@05f57b6e-77ba-4546-b214-b58dacc30356,job_name
+    // For example: job@460e96b9-7a0e-416d-b2c3-4508164b8b1b,job_name
     // Or: job@job_name
     //
     // @plugin Depenizen, Jobs

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/jobs/JobsJobTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/jobs/JobsJobTag.java
@@ -69,14 +69,21 @@ public class JobsJobTag implements ObjectTag, Adjustable {
                 return null;
             }
         }
-        JobsJobTag job = new JobsJobTag(Jobs.getJob(string)); // TODO maybe
+        Job job = Jobs.getJob(string);
+        if (job == null) {
+            if (context == null || context.showErrors()) {
+                Debug.echoError("valueOf JobsJobTag returning null: Invalid job '" + string + "' specified.");
+            }
+            return null;
+        }
+        JobsJobTag jobTag = new JobsJobTag(job);
         if (playerUUID != null) {
-            job.setOwner(playerUUID);
-            if (!job.hasOwner()) {
+            jobTag.setOwner(playerUUID);
+            if (!jobTag.hasOwner()) {
                 Debug.echoError("Player specified in JobsJobTag is not valid");
             }
         }
-        return job;
+        return jobTag;
     }
 
     public static boolean matches(String arg) {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/jobs/JobsJobTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/jobs/JobsJobTag.java
@@ -52,9 +52,6 @@ public class JobsJobTag implements ObjectTag, Adjustable {
         if (string.startsWith("job@")) {
             string = string.substring("job@".length());
         }
-        if (string.contains("@")) {
-            return null;
-        }
         int comma = string.indexOf(',');
         UUID playerUUID = null;
         if (comma > 0) {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/jobs/JobsJobTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/jobs/JobsJobTag.java
@@ -148,7 +148,6 @@ public class JobsJobTag implements ObjectTag, Adjustable {
     /////////////////
 
     public static void register() {
-        PropertyParser.registerPropertyTagHandlers(JobsJobTag.class, tagProcessor);
 
         // <--[tag]
         // @attribute <JobsJobTag.description>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/jobs/JobsPlayerExtensions.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/jobs/JobsPlayerExtensions.java
@@ -6,7 +6,7 @@ import com.denizenscript.depenizen.bukkit.objects.jobs.JobsJobTag;
 import com.gamingmesh.jobs.Jobs;
 import com.gamingmesh.jobs.container.JobsPlayer;
 
-public class JobsPlayerProperties {
+public class JobsPlayerExtensions {
 
     public static void register() {
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/jobs/JobsPlayerProperties.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/jobs/JobsPlayerProperties.java
@@ -1,58 +1,12 @@
 package com.denizenscript.depenizen.bukkit.properties.jobs;
 
+import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
-import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.objects.Mechanism;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.depenizen.bukkit.objects.jobs.JobsJobTag;
 import com.gamingmesh.jobs.Jobs;
-import com.gamingmesh.jobs.container.JobProgression;
 import com.gamingmesh.jobs.container.JobsPlayer;
-import com.denizenscript.denizen.objects.PlayerTag;
-import com.denizenscript.denizencore.objects.ObjectTag;
 
-public class JobsPlayerProperties implements Property {
-
-    @Override
-    public String getPropertyString() {
-        return null;
-    }
-
-    @Override
-    public String getPropertyId() {
-        return "JobsPlayer";
-    }
-
-    @Override
-    public void adjust(Mechanism mechanism) {
-        // None
-    }
-
-    public static boolean describes(ObjectTag object) {
-        return object instanceof PlayerTag;
-    }
-
-    public static JobsPlayerProperties getFrom(ObjectTag object) {
-        if (!describes(object)) {
-            return null;
-        }
-        else {
-            return new JobsPlayerProperties((PlayerTag) object);
-        }
-    }
-
-    public static final String[] handledTags = new String[] {
-            "job", "current_jobs"
-    };
-
-    public static final String[] handledMechs = new String[] {
-    }; // None
-
-    public JobsPlayerProperties(PlayerTag player) {
-        this.player = Jobs.getPlayerManager().getJobsPlayer(player.getName());
-    }
-
-    JobsPlayer player;
+public class JobsPlayerProperties {
 
     public static void register() {
 
@@ -63,8 +17,8 @@ public class JobsPlayerProperties implements Property {
         // @description
         // Returns the job specified with the player's information attached.
         // -->
-        PropertyParser.registerTag(JobsPlayerProperties.class, JobsJobTag.class, JobsJobTag.class, "job", (attribute, object, job) -> {
-            return new JobsJobTag(job.getJob(), object.player);
+        PlayerTag.tagProcessor.registerTag(JobsJobTag.class, JobsJobTag.class, "job", (attribute, object, job) -> {
+            return new JobsJobTag(job.getJob(), Jobs.getPlayerManager().getJobsPlayer(object.getUUID()));
         });
 
         // <--[tag]
@@ -74,12 +28,9 @@ public class JobsPlayerProperties implements Property {
         // @description
         // Returns a list of all jobs that the player is in.
         // -->
-        PropertyParser.registerTag(JobsPlayerProperties.class, ListTag.class, "current_jobs", (attribute, object) -> {
-            ListTag response = new ListTag();
-            for (JobProgression progress : object.player.getJobProgression()) {
-                response.addObject(new JobsJobTag(progress.getJob(), object.player));
-            }
-            return response;
+        PlayerTag.tagProcessor.registerTag(ListTag.class, "current_jobs", (attribute, object) -> {
+            JobsPlayer jobsPlayer = Jobs.getPlayerManager().getJobsPlayer(object.getUUID());
+            return new ListTag(jobsPlayer.getJobProgression(), jobProgression -> new JobsJobTag(jobProgression.getJob(), jobsPlayer));
         });
     }
 }


### PR DESCRIPTION
## Changes

- Moved all of the `Warning`s to `JobsBridge`, just to have them all in once place for easier bumping in the future.
- Changed the `Warning`'s field names to match their IDs, just a standard used in core/Denizen.
- Updated `jobs` (tag base) to the `ListTag` convertor constructor.
- Cleaned up the `jobs_job` constructor tag's handling to use `JobsJobTag` as the param type instead of handling it manually.
- Moved `JobsCommand` registration to be with the rest of the registrations instead of at the bottom.
- Updated `JobsCommand` to modern command handling (with legacy handling for out-of-order args).
- Minor meta correction in `JobsCommand`, new line after dot.
- Added tab-complete for the job names in `JobsCommand`.
- `JobsCommand` now uses the methods on `PlayerManager` instead of the ones on `JobsPlayer`, as these are the ones that handle saving the changes and all (reported on [Discord](https://discord.com/channels/315163488085475337/1122561645303054449)).
- Updated `JobsCommand` to the modern switch syntax.
- Gave all jobs event a general update (modern determinations, switch syntax, meta, and using `tryArgObject` for `JobsJobTag` matching).
- Corrected the UUID in `JobsJobTag`'s meta example (it was meant to be `mcmonkey`'s UUID, but the wrong `mcmonkey` was used. This is a very big problem).
- Implemented `advancedMatches` and added `Matchable` meta to `JobsJobTag`.
- Improved `JobsJobTag#valueOf`'s handling of the player UUID input - It now parses it as just a UUID instead of a `PlayerTag`, mainly as stuff like `PlayerName,job` shouldn't be allowed.
Also changed the checking of whether the player is valid to trying to get it from jobs + a null check, instead of `PlayerTag#isValid`.
- Improved the handling for the job name input to now give a proper error and return null instead of throwing an NPE for invalid names.
- Added a `starts with prefix -> true` into `JobsJobTag#matches`, before doing a `valueOf != null`.
- Changed `JobsJobTag#get/setOwner` to use a `UUID` instead of a `PlayerTag`.
- Did a bit of method re-ordering in `JobsJobTag`, to have less relevant methods such as `get/setPrefix` at the bottom and stuff like `register` higher up.
- Marked `ElementTag`s as plain-text where relevant.
- Changed `JobsJobTag.xp/max_xp (tag)` to use early return.
- Changed `JobsJobTag.level` to use a ternary operator.
- Updated `JobsJobTag.xp (mechanism)` to modern mech registration.
- Marked `JobsJobTag.tagProcessor` as `final`.
- Implemented `JobsJobTag#debuggable`.
- Updated `JobsPlayerProperties` to a modern `JobsPlayerExtensions` extension class.
- Replaced places that got a jobs player by name with getting it by UUID.
- Removed the `registerPropertyTagHandlers` call in `JobsJobTag#register`, as it doesn't look like it has any properties?
- Removed the weird `contains("@") -> null` check in `JobsJobTag#valueOf`, which seems like it was a mistake or something? don't see a reason to have that, but correct me if I'm wrong.
- Changed `JobsJobTag#identify` to use the new `JobsJobTag#identify(prefix, separator)` method.

## Additions

- `jobsSingleLineDescription` deprecation warning for `JobsJobTag.description`, as it was deprecated but didn't have a proper warning.
- `JobsJobTag#identify(String prefix, String separator)` - used by `identify` and `debuggable` to avoid duplicate logic.