### PR TITLE
New MythicMob Tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <dependency>
             <groupId>io.lumine.xikage</groupId>
             <artifactId>mythicmobs</artifactId>
-            <version>5.2.1</version>
+            <version>5.3.5</version>
             <scope>system</scope>
             <systemPath>${basedir}/lib/MythicMobs.jar</systemPath>
         </dependency>


### PR DESCRIPTION
# Additions/changes

- MythicMobsBridgeTags now uses new tag format.
- New `<mythicmobs.item_ids>` tag.
- New `<mythicmobs.skills>` tag.
- New `<mythicmobs.mob_ids>` tag.
- New `<mythicmobs.damage_modifiers[<mob_id>]>` tag.
- New `<mythicmobs.mob_path[<mob_id>]>` tag.
- New `<mythicmobs.item_path[<item_id>]>` tag.
- New `<mythicmobs.packs>` tag.

# Dependency

- MythicMob dependency bumped, ``5.2.1`` --> ``5.3.5``.