### PR TITLE
New MythicMob Tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <dependency>
             <groupId>io.lumine.xikage</groupId>
             <artifactId>mythicmobs</artifactId>
-            <version>5.2.1</version>
+            <version>5.3.5</version>
             <scope>system</scope>
             <systemPath>${basedir}/lib/MythicMobs.jar</systemPath>
         </dependency>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/MythicMobsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/MythicMobsBridge.java
@@ -44,7 +44,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 public class MythicMobsBridge extends Bridge {
 
@@ -127,8 +126,12 @@ public class MythicMobsBridge extends Bridge {
                 if (mob == null) {
                     return null;
                 }
-                return new MapTag(mob.getDamageModifiers().entrySet().stream().map((e) -> Map.entry(new StringHolder(e.getKey()), new ElementTag(e.getValue()))).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-            });
+                MapTag damageModifiers = new MapTag();
+                for (Map.Entry<String, Double> entry : mob.getDamageModifiers().entrySet()) {
+                    damageModifiers.putObject(entry.getKey(), new ElementTag(entry.getValue()));
+                }
+                return damageModifiers;
+        });
 
             // <--[tag]
             // @attribute <mythicmobs.mob_path[<mob_id>]>
@@ -165,7 +168,7 @@ public class MythicMobsBridge extends Bridge {
             // Returns a list of all Mythic pack IDs.
             // -->
             tagProcessor.registerTag(ListTag.class, "packs", (attribute, object) -> {
-                return new ListTag(MythicBukkit.inst().getPackManager().getPacks(), (pack) -> new ElementTag(pack.getName()));
+                return new ListTag(MythicBukkit.inst().getPackManager().getPacks(), (pack) -> new ElementTag(pack.getName(), true));
             });
         };
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/MythicMobsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/MythicMobsBridge.java
@@ -34,6 +34,7 @@ import io.lumine.mythic.bukkit.MythicBukkit;
 import io.lumine.mythic.core.items.ItemExecutor;
 import io.lumine.mythic.core.items.MythicItem;
 import io.lumine.mythic.core.mobs.ActiveMob;
+import io.lumine.mythic.core.mobs.MobExecutor;
 import io.lumine.mythic.core.skills.variables.*;
 import io.lumine.mythic.core.spawning.spawners.MythicSpawner;
 import io.lumine.mythic.core.spawning.spawners.SpawnerManager;
@@ -189,7 +190,7 @@ public class MythicMobsBridge extends Bridge {
         new MythicMobsBridgeTags();
         EntityTag.tagProcessor.custommatchers.add((entityTag, matcher) -> {
             if (matcher.equals("mythic_mob")) {
-                return entityTag.getUUID() != null && isMythicMob(entityTag.getUUID());
+                return entityTag.getUUID() != null && getMobManager().isActiveMob(entityTag.getUUID());
             }
             if (matcher.startsWith("mythic_mob:")) {
                 Entity entity = entityTag.getBukkitEntity();
@@ -290,7 +291,7 @@ public class MythicMobsBridge extends Bridge {
         return MythicBukkit.inst().getMobManager().getMythicMob(name).orElse(null);
     }
 
-    public static MobManager getMobManager() {
+    public static MobExecutor getMobManager() {
         return MythicBukkit.inst().getMobManager();
     }
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/MythicMobsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/MythicMobsBridge.java
@@ -235,7 +235,7 @@ public class MythicMobsBridge extends Bridge {
             }
             String name = attribute.getParam();
             Optional<MythicItem> itemOpt = MythicBukkit.inst().getItemManager().getItem(name);
-            if (itemOpt.isEmpty()) {
+            if (!itemOpt.isPresent()) {
                 attribute.echoError("'" + name + "' is not a valid Mythic item.");
                 return null;
             }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/MythicMobsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/MythicMobsBridge.java
@@ -13,20 +13,19 @@ import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import com.denizenscript.denizencore.tags.PseudoObjectTagBase;
 import com.denizenscript.denizencore.tags.TagManager;
-import com.denizenscript.denizencore.utilities.text.StringHolder;
 import com.denizenscript.depenizen.bukkit.Bridge;
 import com.denizenscript.depenizen.bukkit.commands.mythicmobs.MythicSignalCommand;
 import com.denizenscript.depenizen.bukkit.commands.mythicmobs.MythicSkillCommand;
 import com.denizenscript.depenizen.bukkit.commands.mythicmobs.MythicSpawnCommand;
 import com.denizenscript.depenizen.bukkit.commands.mythicmobs.MythicThreatCommand;
 import com.denizenscript.depenizen.bukkit.events.mythicmobs.MythicMobsDeathEvent;
+import com.denizenscript.depenizen.bukkit.events.mythicmobs.MythicMobsDespawnEvent;
 import com.denizenscript.depenizen.bukkit.events.mythicmobs.MythicMobsSpawnEvent;
 import com.denizenscript.depenizen.bukkit.objects.mythicmobs.MythicMobsMobTag;
 import com.denizenscript.depenizen.bukkit.objects.mythicmobs.MythicSpawnerTag;
 import com.denizenscript.depenizen.bukkit.properties.mythicmobs.MythicMobsEntityProperties;
 import com.denizenscript.depenizen.bukkit.properties.mythicmobs.MythicMobsPlayerProperties;
 import com.denizenscript.depenizen.bukkit.utilities.mythicmobs.MythicMobsLoaders;
-import io.lumine.mythic.api.mobs.MobManager;
 import io.lumine.mythic.api.mobs.MythicMob;
 import io.lumine.mythic.bukkit.BukkitAPIHelper;
 import io.lumine.mythic.bukkit.BukkitAdapter;
@@ -182,6 +181,7 @@ public class MythicMobsBridge extends Bridge {
         PropertyParser.registerProperty(MythicMobsPlayerProperties.class, PlayerTag.class);
         ScriptEvent.registerScriptEvent(MythicMobsDeathEvent.class);
         ScriptEvent.registerScriptEvent(MythicMobsSpawnEvent.class);
+        ScriptEvent.registerScriptEvent(MythicMobsDespawnEvent.class);
         DenizenCore.commandRegistry.registerCommand(MythicSpawnCommand.class);
         DenizenCore.commandRegistry.registerCommand(MythicThreatCommand.class);
         DenizenCore.commandRegistry.registerCommand(MythicSignalCommand.class);
@@ -220,6 +220,7 @@ public class MythicMobsBridge extends Bridge {
         ScriptEvent.ScriptPath.notSwitches.add("mythic_item");
         BukkitScriptEvent.itemCouldMatchableText.add("mythic_item");
         BukkitScriptEvent.itemCouldMatchPrefixes.add("mythic_item");
+
         // <--[tag]
         // @attribute <mythic_item[<name>]>
         // @returns ItemTag

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/MythicMobsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/MythicMobsBridge.java
@@ -1,5 +1,6 @@
 package com.denizenscript.depenizen.bukkit.bridges;
 
+import com.denizenscript.denizen.events.BukkitScriptEvent;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.ItemTag;
 import com.denizenscript.denizen.objects.PlayerTag;
@@ -163,8 +164,10 @@ public class MythicMobsBridge extends Bridge {
             // @description
             // Returns a list of all Mythic pack IDs.
             // -->
-            tagProcessor.registerTag(ListTag.class, "packs", (attribute, object) -> new ListTag(MythicBukkit.inst().getPackManager().getPacks(), (pack) -> new ElementTag(pack.getName())));
-        }
+            tagProcessor.registerTag(ListTag.class, "packs", (attribute, object) -> {
+                return new ListTag(MythicBukkit.inst().getPackManager().getPacks(), (pack) -> new ElementTag(pack.getName()));
+            });
+        };
     }
 
     @Override
@@ -181,7 +184,38 @@ public class MythicMobsBridge extends Bridge {
         DenizenCore.commandRegistry.registerCommand(MythicSkillCommand.class);
         new MythicMobsLoaders().RegisterEvents();
         new MythicMobsBridgeTags();
+        EntityTag.tagProcessor.custommatchers.add((entityTag, matcher) -> {
+            if (matcher.equals("mythic_mob")) {
+                return entityTag.getUUID() != null && isMythicMob(entityTag.getUUID());
+            }
+            if (matcher.startsWith("mythic_mob:")) {
+                Entity entity = entityTag.getBukkitEntity();
+                ActiveMob activeMob = entity != null ? getActiveMob(entity) : null;
+                return activeMob != null && ScriptEvent.runGenericCheck(matcher.substring("mythic_mob:".length()), activeMob.getType().getInternalName());
+            }
+            return null;
+        });
+        ItemTag.tagProcessor.custommatchers.add((itemTag, matcher) -> {
+            if (matcher.equals("mythic_item")) {
+                return MythicBukkit.inst().getItemManager().isMythicItem(itemTag.getItemStack());
+            }
+            if (matcher.startsWith("mythic_item:")) {
+                String mythicID = MythicBukkit.inst().getItemManager().getMythicTypeFromItem(itemTag.getItemStack());
+                return mythicID != null && ScriptEvent.runGenericCheck(matcher.substring("mythic_item:".length()), mythicID);
+            }
+            return null;
+        });
 
+        // <--[data]
+        // @name not_switches
+        // @values mythic_mob, mythic_item
+        // -->
+        ScriptEvent.ScriptPath.notSwitches.add("mythic_mob");
+        EntityTag.specialEntityMatchables.add("mythic_mob");
+        BukkitScriptEvent.entityCouldMatchPrefixes.add("mythic_mob");
+        ScriptEvent.ScriptPath.notSwitches.add("mythic_item");
+        BukkitScriptEvent.itemCouldMatchableText.add("mythic_item");
+        BukkitScriptEvent.itemCouldMatchPrefixes.add("mythic_item");
         // <--[tag]
         // @attribute <mythic_item[<name>]>
         // @returns ItemTag


### PR DESCRIPTION
# Additions/changes

- MythicMobsBridgeTags now uses new tag format.
- New `<mythicmobs.item_ids>` tag.
- New `<mythicmobs.skills>` tag.
- New `<mythicmobs.mob_ids>` tag.
- New `<mythicmobs.damage_modifiers[<mob_id>]>` tag.
- New `<mythicmobs.mob_path[<mob_id>]>` tag.
- New `<mythicmobs.item_path[<item_id>]>` tag.
- New `<mythicmobs.packs>` tag.

# Dependency

- MythicMob dependency bumped, ``5.2.1`` --> ``5.3.5``.

# Author
- [Changes originally authored by 0TickPulse](https://github.com/DenizenScript/Depenizen/pull/392)