### PR TITLE
LuckPerms Bridge Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <dependency>
             <groupId>me.lucko.luckperms</groupId>
             <artifactId>luckperms-api</artifactId>
-            <version>5.0.88</version>
+            <version>5.4.98</version>
             <scope>system</scope>
             <systemPath>${project.basedir}/lib/LuckPerms.jar</systemPath>
         </dependency>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
@@ -1,66 +1,75 @@
 package com.denizenscript.depenizen.bukkit.bridges;
 
-import com.denizenscript.depenizen.bukkit.properties.luckperms.LuckPermsPlayerProperties;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.tags.*;
+import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsGroupTag;
+import com.denizenscript.depenizen.bukkit.properties.luckperms.LuckPermsPlayerExtensions;
 import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsTrackTag;
 import com.denizenscript.depenizen.bukkit.Bridge;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizencore.objects.ObjectFetcher;
-import com.denizenscript.denizencore.tags.TagRunnable;
 import com.denizenscript.denizencore.objects.core.ListTag;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
-import com.denizenscript.denizencore.tags.Attribute;
-import com.denizenscript.denizencore.tags.ReplaceableTagEvent;
-import com.denizenscript.denizencore.tags.TagManager;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
 import net.luckperms.api.track.Track;
 
 public class LuckPermsBridge extends Bridge {
 
+    static class LuckPermsBridgeTags extends PseudoObjectTagBase<LuckPermsBridgeTags> {
+
+        public static LuckPermsBridgeTags instance;
+
+        public LuckPermsBridgeTags() {
+            instance = this;
+            TagManager.registerStaticTagBaseHandler(LuckPermsBridgeTags.class, "luckperms", (t) -> instance);
+        }
+
+        public void register() {
+
+            // <--[tag]
+            // @attribute <luckperms.list_tracks>
+            // @returns ListTag(LuckPermsTrackTag)
+            // @plugin Depenizen, LuckPerms
+            // @description
+            // Returns a list of all tracks.
+            // -->
+            tagProcessor.registerTag(ListTag.class, "list_tracks", (attribute, object) -> {
+                return new ListTag(luckPermsInstance.getTrackManager().getLoadedTracks(), LuckPermsTrackTag::new);
+            });
+
+            // <--[tag]
+            // @attribute <luckperms.track[<track_name>]>
+            // @returns LuckPermsTrackTag
+            // @plugin Depenizen, LuckPerms
+            // @description
+            // Returns the track from the name given.
+            // -->
+            tagProcessor.registerTag(LuckPermsTrackTag.class, ElementTag.class, "track", (attribute, object, name) -> {
+                Track track = luckPermsInstance.getTrackManager().getTrack(name.toString());
+                return track != null ? new LuckPermsTrackTag(track) : null;
+            });
+
+            // <--[tag]
+            // @attribute <luckperms.list_groups>
+            // @returns ListTag(LuckPermsGrupTag)
+            // @plugin Depenizen, LuckPerms
+            // @description
+            // Returns a list of all luckperms groups.
+            // -->
+            tagProcessor.registerTag(ListTag.class, "list_groups", (attribute, object) -> {
+                return new ListTag(luckPermsInstance.getGroupManager().getLoadedGroups(), LuckPermsGroupTag::new);
+            });
+        }
+
+    }
+
     public static LuckPerms luckPermsInstance;
 
     @Override
     public void init() {
         luckPermsInstance = LuckPermsProvider.get();
-        TagManager.registerTagHandler(new TagRunnable.RootForm() {
-            @Override
-            public void run(ReplaceableTagEvent event) {
-                tagEvent(event);
-            }
-        }, "luckperms");
-        ObjectFetcher.registerWithObjectFetcher(LuckPermsTrackTag.class);
-        PropertyParser.registerProperty(LuckPermsPlayerProperties.class, PlayerTag.class);
-    }
-
-    public void tagEvent(ReplaceableTagEvent event) {
-        Attribute attribute = event.getAttributes().fulfill(1);
-
-        // <--[tag]
-        // @attribute <luckperms.list_tracks>
-        // @returns ListTag(LuckPermsTrackTag)
-        // @plugin Depenizen, LuckPerms
-        // @description
-        // Returns a list of all tracks.
-        // -->
-        if (attribute.startsWith("list_tracks")) {
-            ListTag tracks = new ListTag();
-            for (Track track : luckPermsInstance.getTrackManager().getLoadedTracks()) {
-                tracks.addObject(new LuckPermsTrackTag(track));
-            }
-            event.setReplacedObject(tracks.getObjectAttribute(attribute.fulfill(1)));
-        }
-
-        // <--[tag]
-        // @attribute <luckperms.track[<track_name>]>
-        // @returns LuckPermsTrackTag
-        // @plugin Depenizen, LuckPerms
-        // @description
-        // Returns the track from the name given.
-        // -->
-        if (attribute.startsWith("track")) {
-            if (attribute.hasParam()) {
-                event.setReplacedObject(attribute.paramAsType(LuckPermsTrackTag.class).getObjectAttribute(attribute.fulfill(1)));
-            }
-        }
+        LuckPermsPlayerExtensions.register();
+        ObjectFetcher.registerWithObjectFetcher(LuckPermsGroupTag.class, LuckPermsGroupTag.tagProcessor).generateBaseTag();
+        ObjectFetcher.registerWithObjectFetcher(LuckPermsTrackTag.class, LuckPermsTrackTag.tagProcessor).generateBaseTag();
+        new LuckPermsBridgeTags();
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
@@ -42,7 +42,9 @@ public class LuckPermsBridge extends Bridge {
             // @description
             // Returns the track from the name given.
             // -->
-            tagProcessor.registerTag(LuckPermsTrackTag.class, LuckPermsTrackTag.class, "track", (attribute, object, track) -> track);
+            tagProcessor.registerTag(LuckPermsTrackTag.class, LuckPermsTrackTag.class, "track", (attribute, object, track) -> {
+                return track;
+            });
 
             // <--[tag]
             // @attribute <luckperms.list_groups>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
@@ -1,26 +1,26 @@
 package com.denizenscript.depenizen.bukkit.bridges;
 
-import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.tags.*;
-import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsGroupTag;
-import com.denizenscript.depenizen.bukkit.properties.luckperms.LuckPermsPlayerExtensions;
-import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsTrackTag;
-import com.denizenscript.depenizen.bukkit.Bridge;
 import com.denizenscript.denizencore.objects.ObjectFetcher;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.tags.PseudoObjectTagBase;
+import com.denizenscript.denizencore.tags.TagManager;
+import com.denizenscript.depenizen.bukkit.Bridge;
+import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsGroupTag;
+import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsTrackTag;
+import com.denizenscript.depenizen.bukkit.properties.luckperms.LuckPermsPlayerExtensions;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
-import net.luckperms.api.track.Track;
 
 public class LuckPermsBridge extends Bridge {
 
-    static class LuckPermsBridgeTags extends PseudoObjectTagBase<LuckPermsBridgeTags> {
+    static class LuckPermsTagBase extends PseudoObjectTagBase<LuckPermsTagBase> {
 
-        public static LuckPermsBridgeTags instance;
+        public static LuckPermsTagBase instance;
 
-        public LuckPermsBridgeTags() {
+        public LuckPermsTagBase() {
             instance = this;
-            TagManager.registerStaticTagBaseHandler(LuckPermsBridgeTags.class, "luckperms", (t) -> instance);
+            TagManager.registerStaticTagBaseHandler(LuckPermsTagBase.class, "luckperms", (t) -> instance);
         }
 
         public void register() {
@@ -44,13 +44,12 @@ public class LuckPermsBridge extends Bridge {
             // Returns the track from the name given.
             // -->
             tagProcessor.registerTag(LuckPermsTrackTag.class, ElementTag.class, "track", (attribute, object, name) -> {
-                Track track = luckPermsInstance.getTrackManager().getTrack(name.toString());
-                return track != null ? new LuckPermsTrackTag(track) : null;
+                return attribute.paramAsType(LuckPermsTrackTag.class);
             });
 
             // <--[tag]
             // @attribute <luckperms.list_groups>
-            // @returns ListTag(LuckPermsGrupTag)
+            // @returns ListTag(LuckPermsGroupTag)
             // @plugin Depenizen, LuckPerms
             // @description
             // Returns a list of all luckperms groups.
@@ -68,8 +67,17 @@ public class LuckPermsBridge extends Bridge {
     public void init() {
         luckPermsInstance = LuckPermsProvider.get();
         LuckPermsPlayerExtensions.register();
-        ObjectFetcher.registerWithObjectFetcher(LuckPermsGroupTag.class, LuckPermsGroupTag.tagProcessor).generateBaseTag();
-        ObjectFetcher.registerWithObjectFetcher(LuckPermsTrackTag.class, LuckPermsTrackTag.tagProcessor).generateBaseTag();
-        new LuckPermsBridgeTags();
+        ObjectFetcher.registerWithObjectFetcher(LuckPermsGroupTag.class, LuckPermsGroupTag.tagProcessor);
+        ObjectFetcher.registerWithObjectFetcher(LuckPermsTrackTag.class, LuckPermsTrackTag.tagProcessor);
+        new LuckPermsTagBase();
+
+        // <--[tag]
+        // @attribute <luckperms_group[<name>]>
+        // @returns LuckPermsGroupTag
+        // @plugin Depenizen, LuckPerms
+        // @description
+        // Returns the luckperms group tag with the given name.
+        // -->
+        TagManager.registerTagHandler(LuckPermsGroupTag.class, LuckPermsGroupTag.class, "luckperms_group", (attribute, param) -> param);
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
@@ -1,7 +1,6 @@
 package com.denizenscript.depenizen.bukkit.bridges;
 
 import com.denizenscript.denizencore.objects.ObjectFetcher;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.tags.PseudoObjectTagBase;
 import com.denizenscript.denizencore.tags.TagManager;
@@ -43,9 +42,7 @@ public class LuckPermsBridge extends Bridge {
             // @description
             // Returns the track from the name given.
             // -->
-            tagProcessor.registerTag(LuckPermsTrackTag.class, ElementTag.class, "track", (attribute, object, name) -> {
-                return attribute.paramAsType(LuckPermsTrackTag.class);
-            });
+            tagProcessor.registerTag(LuckPermsTrackTag.class, LuckPermsTrackTag.class, "track", (attribute, object, track) -> track);
 
             // <--[tag]
             // @attribute <luckperms.list_groups>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
@@ -77,6 +77,8 @@ public class LuckPermsBridge extends Bridge {
         // @description
         // Returns the luckperms group tag with the given name.
         // -->
-        TagManager.registerTagHandler(LuckPermsGroupTag.class, LuckPermsGroupTag.class, "luckperms_group", (attribute, param) -> param);
+        TagManager.registerTagHandler(LuckPermsGroupTag.class, LuckPermsGroupTag.class, "luckperms_group", (attribute, param) -> {
+            return param;
+        });
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
@@ -1,0 +1,150 @@
+package com.denizenscript.depenizen.bukkit.objects.luckperms;
+
+import com.denizenscript.denizencore.objects.Fetchable;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.tags.ObjectTagProcessor;
+import com.denizenscript.denizencore.tags.TagContext;
+import com.denizenscript.depenizen.bukkit.bridges.LuckPermsBridge;
+import net.luckperms.api.model.group.Group;
+
+import java.util.OptionalInt;
+
+public class LuckPermsGroupTag implements ObjectTag {
+
+    public static ObjectTagProcessor<LuckPermsGroupTag> tagProcessor = new ObjectTagProcessor<>();
+
+    // <--[ObjectType]
+    // @name LuckPermsGroupTag
+    // @prefix luckpermsgroup
+    // @base ElementTag
+    // @format
+    // The identity format for group is <group_name>
+    // For example, 'luckpermsgroup@my_group'.
+    //
+    // @plugin Depenizen, LuckPerms
+    // @description
+    // A LuckPermsGroupTag represents a LuckPerms group.
+    //
+    // -->
+
+    @Fetchable("luckpermsgroup")
+    public static LuckPermsGroupTag valueOf(String string, TagContext context) {
+        if (string == null) {
+            return null;
+        }
+        string = string.replace("luckpermsgroup@", "");
+        Group group = LuckPermsBridge.luckPermsInstance.getGroupManager().getGroup(string);
+        if (group == null) {
+            return null;
+        }
+        return new LuckPermsGroupTag(group);
+    }
+
+    public static boolean matches(String arg) {
+        arg = arg.replace("luckpermsgroup@", "");
+        return LuckPermsBridge.luckPermsInstance.getGroupManager().getGroup(arg) != null;
+    }
+
+    Group group = null;
+
+    public LuckPermsGroupTag(Group group) { this.group = group; }
+
+    String prefix = "LuckPermsGroup";
+
+    @Override
+    public String getPrefix() { return prefix; }
+
+    @Override
+    public ObjectTag setPrefix(String prefix) {
+        this.prefix = prefix;
+        return this;
+    }
+
+    @Override
+    public boolean isUnique() { return true; }
+
+    @Override
+    public String identify() { return "luckpermsgroup@" + group.getName(); }
+
+    @Override
+    public String identifySimple() {
+        return identify();
+    }
+
+    @Override
+    public String toString() {
+        return identify();
+    }
+
+    @Override
+    public ObjectTag getObjectAttribute(Attribute attribute) {
+        return tagProcessor.getObjectAttribute(this, attribute);
+    }
+
+    public Group getGroup() {
+        return group;
+    }
+
+    public static void register() {
+
+        // <--[tag]
+        // @attribute <LuckPermsGroupTag.name>
+        // @returns ElementTag
+        // @plugin Depenizen, LuckPerms
+        // @description
+        // Returns the group's name.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "name", (attribute, object) -> {
+            return new ElementTag(object.getGroup().getName(), true);
+        });
+
+        // <--[tag]
+        // @attribute <LuckPermsGroupTag.prefix>
+        // @returns ElementTag
+        // @plugin Depenizen, LuckPerms
+        // @description
+        // Returns the group's prefix, if any.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "prefix", (attribute, object) -> {
+            String prefix = object.getGroup().getCachedData().getMetaData().getPrefix();
+            return prefix != null ? new ElementTag(prefix, true) : null;
+        });
+
+        // <--[tag]
+        // @attribute <LuckPermsGroupTag.suffix>
+        // @returns ElementTag
+        // @plugin Depenizen, LuckPerms
+        // @description
+        // Returns the group's suffix, if any.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "suffix", (attribute, object) -> {
+            String suffix = object.getGroup().getCachedData().getMetaData().getSuffix();
+            return suffix != null ? new ElementTag(suffix, true) : null;
+        });
+
+        // <--[tag]
+        // @attribute <LuckPermsGroupTag.weight>
+        // @returns ElementTag
+        // @plugin Depenizen, LuckPerms
+        // @description
+        // Returns the group's weight, if any.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "weight", (attribute, object) -> {
+            OptionalInt weight = object.getGroup().getWeight();
+            return weight.isPresent() ? new ElementTag(weight.getAsInt()) : null;
+        });
+
+        // <--[tag]
+        // @attribute <LuckPermsGroupTag.has_permission[permission.node]>
+        // @returns ElementTag(Boolean)
+        // @plugin Depenizen, LuckPerms
+        // @description
+        // Returns whether the group has the specified permission node.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, ElementTag.class, "has_permission", (attribute, object, p) -> {
+            return new ElementTag(object.getGroup().getCachedData().getPermissionData().checkPermission(p.toString()).asBoolean());
+        });
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
@@ -30,7 +30,7 @@ public class LuckPermsGroupTag implements ObjectTag {
     @Fetchable("luckpermsgroup")
     public static LuckPermsGroupTag valueOf(String string, TagContext context) {
         if (string.startsWith("luckpermsgroup@")) {
-            string = string.substring("@luckpermsgroup".length());
+            string = string.substring("luckpermsgroup@".length());
         }
         Group group = LuckPermsBridge.luckPermsInstance.getGroupManager().getGroup(string);
         if (group == null) {
@@ -97,54 +97,54 @@ public class LuckPermsGroupTag implements ObjectTag {
     public static void register() {
 
         // <--[tag]
-        // @attribute <LuckPermsGroupTag.name>
+        // @attribute <LuckPermsGroupTag.group_name>
         // @returns ElementTag
         // @plugin Depenizen, LuckPerms
         // @description
         // Returns the group's name.
         // -->
-        tagProcessor.registerStaticTag(ElementTag.class, "name", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ElementTag.class, "group_name", (attribute, object) -> {
             return new ElementTag(object.getGroup().getName(), true);
         });
 
         // <--[tag]
-        // @attribute <LuckPermsGroupTag.prefix>
+        // @attribute <LuckPermsGroupTag.group_prefix>
         // @returns ElementTag
         // @plugin Depenizen, LuckPerms
         // @description
         // Returns the group's prefix, if any.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "prefix", (attribute, object) -> {
+        tagProcessor.registerTag(ElementTag.class, "group_prefix", (attribute, object) -> {
             String prefix = object.getGroup().getCachedData().getMetaData().getPrefix();
             return prefix != null ? new ElementTag(prefix, true) : null;
         });
 
         // <--[tag]
-        // @attribute <LuckPermsGroupTag.suffix>
+        // @attribute <LuckPermsGroupTag.group_suffix>
         // @returns ElementTag
         // @plugin Depenizen, LuckPerms
         // @description
         // Returns the group's suffix, if any.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "suffix", (attribute, object) -> {
+        tagProcessor.registerTag(ElementTag.class, "group_suffix", (attribute, object) -> {
             String suffix = object.getGroup().getCachedData().getMetaData().getSuffix();
             return suffix != null ? new ElementTag(suffix, true) : null;
         });
 
         // <--[tag]
-        // @attribute <LuckPermsGroupTag.weight>
+        // @attribute <LuckPermsGroupTag.group_weight>
         // @returns ElementTag
         // @plugin Depenizen, LuckPerms
         // @description
         // Returns the group's weight, if any.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "weight", (attribute, object) -> {
+        tagProcessor.registerTag(ElementTag.class, "group_weight", (attribute, object) -> {
             OptionalInt weight = object.getGroup().getWeight();
             return weight.isPresent() ? new ElementTag(weight.getAsInt()) : null;
         });
 
         // <--[tag]
-        // @attribute <LuckPermsGroupTag.has_permission[permission.node]>
+        // @attribute <LuckPermsGroupTag.has_permission[<permission.node>]>
         // @returns ElementTag(Boolean)
         // @plugin Depenizen, LuckPerms
         // @description

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
@@ -13,8 +13,6 @@ import java.util.OptionalInt;
 
 public class LuckPermsGroupTag implements ObjectTag {
 
-    public static ObjectTagProcessor<LuckPermsGroupTag> tagProcessor = new ObjectTagProcessor<>();
-
     // <--[ObjectType]
     // @name LuckPermsGroupTag
     // @prefix luckpermsgroup
@@ -31,10 +29,9 @@ public class LuckPermsGroupTag implements ObjectTag {
 
     @Fetchable("luckpermsgroup")
     public static LuckPermsGroupTag valueOf(String string, TagContext context) {
-        if (string == null) {
-            return null;
+        if (string.startsWith("luckpermsgroup@")) {
+            string = string.substring("@luckpermsgroup".length());
         }
-        string = string.replace("luckpermsgroup@", "");
         Group group = LuckPermsBridge.luckPermsInstance.getGroupManager().getGroup(string);
         if (group == null) {
             return null;
@@ -43,18 +40,24 @@ public class LuckPermsGroupTag implements ObjectTag {
     }
 
     public static boolean matches(String arg) {
-        arg = arg.replace("luckpermsgroup@", "");
-        return LuckPermsBridge.luckPermsInstance.getGroupManager().getGroup(arg) != null;
+        if (arg.startsWith("luckpermsgroup@")) {
+            return true;
+        }
+        return LuckPermsBridge.luckPermsInstance.getGroupManager().isLoaded(arg);
     }
 
-    Group group = null;
+    Group group;
 
-    public LuckPermsGroupTag(Group group) { this.group = group; }
+    public LuckPermsGroupTag(Group group) {
+        this.group = group;
+    }
 
     String prefix = "LuckPermsGroup";
 
     @Override
-    public String getPrefix() { return prefix; }
+    public String getPrefix() {
+        return prefix;
+    }
 
     @Override
     public ObjectTag setPrefix(String prefix) {
@@ -63,10 +66,14 @@ public class LuckPermsGroupTag implements ObjectTag {
     }
 
     @Override
-    public boolean isUnique() { return true; }
+    public boolean isUnique() {
+        return true;
+    }
 
     @Override
-    public String identify() { return "luckpermsgroup@" + group.getName(); }
+    public String identify() {
+        return "luckpermsgroup@" + group.getName();
+    }
 
     @Override
     public String identifySimple() {
@@ -144,7 +151,10 @@ public class LuckPermsGroupTag implements ObjectTag {
         // Returns whether the group has the specified permission node.
         // -->
         tagProcessor.registerTag(ElementTag.class, ElementTag.class, "has_permission", (attribute, object, p) -> {
-            return new ElementTag(object.getGroup().getCachedData().getPermissionData().checkPermission(p.toString()).asBoolean());
+            return new ElementTag(object.getGroup().getCachedData().getPermissionData().checkPermission(p.asString()).asBoolean());
         });
     }
+
+    public static final ObjectTagProcessor<LuckPermsGroupTag> tagProcessor = new ObjectTagProcessor<>();
+
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
@@ -103,7 +103,7 @@ public class LuckPermsGroupTag implements ObjectTag {
         // @description
         // Returns the group's name.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "name", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ElementTag.class, "name", (attribute, object) -> {
             return new ElementTag(object.getGroup().getName(), true);
         });
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsTrackTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsTrackTag.java
@@ -154,7 +154,7 @@ public class LuckPermsTrackTag implements ObjectTag {
         // This returns names of the groups instead of <@link objecttype LuckPermsGroupTag>s, as groups can be unloaded from LuckPerms but still be part of the track.
         // If a player input is specified, limits to only the groups that the player is in.
         // -->
-        tagProcessor.registerTag(ListTag.class,"groups", (attribute, object) -> {
+        tagProcessor.registerTag(ListTag.class, "groups", (attribute, object) -> {
             List<String> trackGroups = object.getTrack().getGroups();
             if (!attribute.hasParam()) {
                 return new ListTag(trackGroups, true);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsTrackTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsTrackTag.java
@@ -142,7 +142,7 @@ public class LuckPermsTrackTag implements ObjectTag {
         // @description
         // Returns the name of the track.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "name", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ElementTag.class, "name", (attribute, object) -> {
             return new ElementTag(object.getTrack().getName(), true);
         });
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsTrackTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsTrackTag.java
@@ -21,8 +21,6 @@ import java.util.List;
 
 public class LuckPermsTrackTag implements ObjectTag {
 
-    public static ObjectTagProcessor<LuckPermsTrackTag> tagProcessor = new ObjectTagProcessor<>();
-
     // <--[ObjectType]
     // @name LuckPermsTrackTag
     // @prefix luckpermstrack
@@ -123,7 +121,9 @@ public class LuckPermsTrackTag implements ObjectTag {
         return identify();
     }
 
-    public Track getTrack() { return track; }
+    public Track getTrack() {
+        return track;
+    }
 
     @Override
     public ObjectTag getObjectAttribute(Attribute attribute) {
@@ -140,7 +140,7 @@ public class LuckPermsTrackTag implements ObjectTag {
         // Returns the name of the track.
         // -->
         tagProcessor.registerTag(ElementTag.class, "name", (attribute, object) -> {
-            return new ElementTag(object.getTrack().getName());
+            return new ElementTag(object.getTrack().getName(), true);
         });
 
         // <--[tag]
@@ -154,7 +154,7 @@ public class LuckPermsTrackTag implements ObjectTag {
         tagProcessor.registerTag(ListTag.class,"groups", (attribute, object) -> {
             List<String> trackGroups = object.getTrack().getGroups();
             if (!attribute.hasParam()) {
-                return new ListTag(trackGroups);
+                return new ListTag(trackGroups, true);
             }
             PlayerTag player = attribute.paramAsType(PlayerTag.class);
             if (player == null) {
@@ -171,7 +171,7 @@ public class LuckPermsTrackTag implements ObjectTag {
                     .filter(net.luckperms.api.node.Node::getValue)
                     .map(InheritanceNode::getGroupName)
                     .filter(trackGroups::contains).toList();
-            return new ListTag(memberGroups);
+            return new ListTag(memberGroups, true);
         });
 
         // <--[tag]
@@ -218,4 +218,7 @@ public class LuckPermsTrackTag implements ObjectTag {
             return groups;
         });
     }
+
+    public static final ObjectTagProcessor<LuckPermsTrackTag> tagProcessor = new ObjectTagProcessor<>();
+
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsTrackTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsTrackTag.java
@@ -58,7 +58,10 @@ public class LuckPermsTrackTag implements ObjectTag {
     }
 
     public static boolean matches(String arg) {
-        return arg.startsWith("luckpermstrack@");
+        if (arg.startsWith("luckpermstrack@")) {
+            return true;
+        }
+        return LuckPermsBridge.luckPermsInstance.getTrackManager().isLoaded(arg);
     }
 
     /////////////////////

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/luckperms/LuckPermsPlayerExtensions.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/luckperms/LuckPermsPlayerExtensions.java
@@ -53,7 +53,7 @@ public class LuckPermsPlayerExtensions {
         // @returns LuckPermsGroupTag
         // @plugin Depenizen, LuckPerms
         // @description
-        // Returns a players primary group.
+        // Returns a player's primary group.
         // -->
         PlayerTag.tagProcessor.registerTag(LuckPermsGroupTag.class, "luckperms_primary_group", (attribute, player) -> {
             User user = LuckPermsBridge.luckPermsInstance.getUserManager().getUser(player.getUUID());


### PR DESCRIPTION
### Additions

#### LuckPermsGroup
- `LuckPermsGroupTag` object -  representing luckperms groups
- `<LuckPermsGroupTag.name>` tag - group's name
- `<LuckPermsGroupTag.prefix>` tag - group's prefix, if any
- `<LuckPermsGroupTag.suffix>` tag - group's suffix, if any
- `<LuckPermsGroupTag.weight>` tag - group's weight, if any
- `<LuckPermsGroupTag.has_permission[permission.node]>` tag - whether a group has specified permission node

#### LuckPerms
- `<luckperms.list_groups>` tag - list of loaded luckperms groups

#### Player
- `<PlayerTag.luckperms_primary_group>` tag - self explanatory

### Changes

- Update `luckperms` object to pseudo-object
- Update proper registration for tags
- `LuckPermsPlayerProperties` -> `LuckPermsPlayerExtensions`
- Bump lib version `5.0.88` -> `5.4.98`