### PR TITLE
Add support for NoteblockAPI's `PositionSongPlayer`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <dependency>
             <groupId>com.github.koca2000</groupId>
             <artifactId>NoteBlockAPI</artifactId>
-            <version>1.6.2</version>
+            <version>1.2.2.1</version>
             <scope>system</scope>
             <systemPath>${project.basedir}/lib/NoteBlockAPI.jar</systemPath>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <dependency>
             <groupId>com.github.koca2000</groupId>
             <artifactId>NoteBlockAPI</artifactId>
-            <version>1.2.2.1</version>
+            <version>1.6.2</version>
             <scope>system</scope>
             <systemPath>${project.basedir}/lib/NoteBlockAPI.jar</systemPath>
         </dependency>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
@@ -23,7 +23,7 @@ public class NBSCommand extends AbstractCommand {
 
     public NBSCommand() {
         setName("nbs");
-        setSyntax("nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>)");
+        setSyntax("nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>/{16})");
         setRequiredArguments(1, 5);
         autoCompile();
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
@@ -23,14 +23,14 @@ public class NBSCommand extends AbstractCommand {
 
     public NBSCommand() {
         setName("nbs");
-        setSyntax("nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>{16})");
+        setSyntax("nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>/{16})");
         setRequiredArguments(1, 5);
         autoCompile();
     }
 
     // <--[command]
     // @Name nbs
-    // @Syntax nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>{16})
+    // @Syntax nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>/{16})
     // @Group Depenizen
     // @Plugin Depenizen, NoteBlockAPI
     // @Required 1

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
@@ -1,5 +1,6 @@
 package com.denizenscript.depenizen.bukkit.commands.noteblockapi;
 
+import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.scripts.commands.generator.*;
@@ -95,8 +96,12 @@ public class NBSCommand extends AbstractCommand {
                     Debug.echoError(scriptEntry, "File not specified!");
                     return;
                 }
-                String directory = URLDecoder.decode(System.getProperty("user.dir"));
-                Song s = NBSDecoder.parse(new File(directory + "/plugins/Denizen/" + file + ".nbs"));
+                File songFile = new File(Denizen.getInstance().getDataFolder(), file + ".nbs");
+                if (!Utilities.canReadFile(songFile)) {
+                    Debug.echoError("Cannot read from that file path due to security settings in Denizen/config.yml.");
+                    return;
+                }
+                Song s = NBSDecoder.parse(songFile);
                 SongPlayer sp = new RadioSongPlayer(s);
                 if (location != null) {
                     sp = new PositionSongPlayer(s);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
@@ -92,7 +92,7 @@ public class NBSCommand extends AbstractCommand {
         switch (action) {
             case PLAY -> {
                 if (file == null) {
-                    Debug.echoError(scriptEntry, "File not specified!");
+                    Debug.echoError("File not specified!");
                     return;
                 }
                 File songFile = new File(Denizen.getInstance().getDataFolder(), file + ".nbs");

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
@@ -30,7 +30,7 @@ public class NBSCommand extends AbstractCommand {
 
     // <--[command]
     // @Name nbs
-    // @Syntax nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>)
+    // @Syntax nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>/{16})
     // @Group Depenizen
     // @Plugin Depenizen, NoteBlockAPI
     // @Required 1

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
@@ -41,7 +41,7 @@ public class NBSCommand extends AbstractCommand {
     // Plays a .nbs file for the targets, being players specified.
     // If no targets are specified, the target will be the player in the queue.
     // Optionally specify the location to play the song from using the 'at' argument. Players must still be added using 'targets' in order to hear the song when they are within range.
-    // Setting 'distance' will change the range that a player must be in to hear the song. Numbers below 16 will decrease volume, not decrease range. Numbers greater than 16 will increase range.
+    // Setting 'distance' will change the range in blocks that a player must be in to hear the song. Numbers below 16 will decrease volume, not decrease range. Numbers greater than 16 will increase range.
     // Note block song files are created using NoteBlockStudio or other programs.
     // The file path starts in the denizen folder: /plugins/Denizen/
     //
@@ -64,6 +64,13 @@ public class NBSCommand extends AbstractCommand {
     // Use to stop the current song playing for all online players.
     // - nbs stop targets:<server.online_players>
     //
+    // @Usage
+    // Use to play a song only for the linked player in a queue at a specified location.
+    // - nbs play file:MySong at:<[my_location]>
+    //
+    // @Usage
+    // Use to play a song to everyone online if they are 30 blocks away from a specified location.
+    // - nbs play file:MySong targets:<server.online_players> at:<[my_location]> distance:30
     // -->
 
     public enum Action {PLAY, STOP}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
@@ -17,7 +17,6 @@ import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 
 import java.io.File;
-import java.net.URLDecoder;
 import java.util.List;
 
 public class NBSCommand extends AbstractCommand {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/noteblockapi/NBSCommand.java
@@ -23,14 +23,14 @@ public class NBSCommand extends AbstractCommand {
 
     public NBSCommand() {
         setName("nbs");
-        setSyntax("nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>/{16})");
+        setSyntax("nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>{16})");
         setRequiredArguments(1, 5);
         autoCompile();
     }
 
     // <--[command]
     // @Name nbs
-    // @Syntax nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>/{16})
+    // @Syntax nbs [play/stop] (file:<file_path>) (targets:<entity>|...) (at:<location>) (distance:<#>{16})
     // @Group Depenizen
     // @Plugin Depenizen, NoteBlockAPI
     // @Required 1
@@ -86,7 +86,7 @@ public class NBSCommand extends AbstractCommand {
                 targets = List.of(Utilities.getEntryPlayer(scriptEntry));
             }
             else {
-                throw new InvalidArgumentsRuntimeException("Must specify players to add or remove!");
+                throw new InvalidArgumentsRuntimeException("Must specify players that can hear the song!");
             }
         }
         switch (action) {
@@ -101,8 +101,11 @@ public class NBSCommand extends AbstractCommand {
                     return;
                 }
                 Song s = NBSDecoder.parse(songFile);
-                SongPlayer sp = new RadioSongPlayer(s);
-                if (location != null) {
+                SongPlayer sp;
+                if (location == null) {
+                    sp = new RadioSongPlayer(s);
+                }
+                else {
                     sp = new PositionSongPlayer(s);
                     ((PositionSongPlayer) sp).setTargetLocation(location);
                     ((PositionSongPlayer) sp).setDistance(distance);


### PR DESCRIPTION
# Play NBS songs from a certain location

### Changes
- Update NoteblockAPI version (can be reverted if necessary)
- Add `at:<location>` argument to specify the location the song should play from
- Add `distance:<#>` argument to control the hearing range (and volume if number < 16)
- Make command use `autoExecute`
- Edit syntax line so `<file path>` is `<file_path>` because it was causing a weird tab-completion issue: 
![image](https://github.com/DenizenScript/Depenizen/assets/63469489/4c6236e8-6886-49e7-b66a-e5b4494a3633)

### Notes
- Not sure why the distance only increases the range when its greater than 16. When it's less than 16 the volume just lowers but you can still just barely hear it 16 blocks away, even when the distance is set to `5` or something like that

requested by [Josh65](https://discord.com/channels/315163488085475337/1211040471158095933)