### PR TITLE
Clientizen: properly read bytes from `ByteBuf`

### DIFF
--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/ClientizenPacketOut.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/ClientizenPacketOut.java
@@ -1,6 +1,5 @@
 package com.denizenscript.depenizen.bukkit.clientizen.network;
 
-import com.denizenscript.depenizen.bukkit.clientizen.network.NetworkManager;
 import com.denizenscript.depenizen.bukkit.networking.PacketOut;
 
 public abstract class ClientizenPacketOut extends PacketOut {

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/NetworkManager.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/NetworkManager.java
@@ -4,6 +4,7 @@ import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.depenizen.bukkit.Depenizen;
 import com.denizenscript.depenizen.bukkit.clientizen.ClientizenBridge;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -52,7 +53,11 @@ public class NetworkManager implements PluginMessageListener {
         }
         ByteBuf buf = Unpooled.buffer();
         packet.writeTo(buf);
-        target.sendPluginMessage(Depenizen.instance, packet.channel, buf.array());
+        target.sendPluginMessage(Depenizen.instance, packet.channel, bufToBytes(buf));
+    }
+
+    public static byte[] bufToBytes(ByteBuf buf) {
+        return ByteBufUtil.getBytes(buf, buf.readerIndex(), buf.readableBytes(), false);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/packets/SetScriptsPacketOut.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/clientizen/network/packets/SetScriptsPacketOut.java
@@ -1,6 +1,7 @@
 package com.denizenscript.depenizen.bukkit.clientizen.network.packets;
 
 import com.denizenscript.depenizen.bukkit.clientizen.network.ClientizenPacketOut;
+import com.denizenscript.depenizen.bukkit.clientizen.network.NetworkManager;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
@@ -11,14 +12,14 @@ public class SetScriptsPacketOut extends ClientizenPacketOut {
     public SetScriptsPacketOut(Map<String, String> scripts) {
         ByteBuf buf = Unpooled.buffer();
         writeStringMap(buf, scripts);
-        this.scripts = buf.array();
+        this.scriptsData = NetworkManager.bufToBytes(buf);
     }
 
-    private final byte[] scripts;
+    private final byte[] scriptsData;
 
     @Override
     public void writeTo(ByteBuf buf) {
-        buf.writeBytes(scripts);
+        buf.writeBytes(scriptsData);
     }
 
     @Override


### PR DESCRIPTION
See [Discord](https://discord.com/channels/315163488085475337/1024819028918796359/1236791826602786836).
`ByteBuf#array` returns the entire backing array, which could be larger than the amount of bytes actually written, resulting in a bunch of extra nothing-bytes.

## Additions

- `NetworkManager#bufToBytes` - properly gets a `byte[]` from a `ByteBuf`.

## Changes

- `NetworkManager#send` and `SetScriptsPacketOut` now use `NetworkManager#bufToBytes`.
- Renamed `SetScriptsPacketOut.scripts` to `scriptsData`.