### PR TITLE
Account for conflicting plugin names

### DIFF
--- a/src/main/java/com/denizenscript/depenizen/bukkit/Depenizen.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/Depenizen.java
@@ -21,9 +21,11 @@ public class Depenizen extends JavaPlugin {
 
     public static Depenizen instance;
 
-    public HashMap<String, Supplier<Bridge>> allBridges = new HashMap<>();
+    public HashMap<String, BridgeData> allBridges = new HashMap<>();
 
     public HashMap<String, Bridge> loadedBridges = new HashMap<>();
+
+    public record BridgeData(String classCheck, Supplier<Bridge> creator) {}
 
     @Override
     public void onEnable() {
@@ -31,7 +33,7 @@ public class Depenizen extends JavaPlugin {
         saveDefaultConfig();
         instance = this;
         registerCoreBridges();
-        for (Map.Entry<String, Supplier<Bridge>> bridge : allBridges.entrySet()) {
+        for (Map.Entry<String, BridgeData> bridge : allBridges.entrySet()) {
             loadBridge(bridge.getKey(), bridge.getValue());
         }
         try {
@@ -70,14 +72,23 @@ public class Depenizen extends JavaPlugin {
         }
     }
 
-    public void loadBridge(String name, Supplier<Bridge> bridgeSupplier) {
+    public void loadBridge(String name, BridgeData bridgeData) {
         Plugin plugin = Bukkit.getPluginManager().getPlugin(name);
         if (plugin == null) {
             return;
         }
+        if (bridgeData.classCheck != null) {
+            try {
+                Class.forName(bridgeData.classCheck);
+            }
+            catch (ClassNotFoundException e) {
+                Debug.log("Tried loading plugin bridge for '" + name + "', but could not match class '" + bridgeData.classCheck + "'.");
+                return;
+            }
+        }
         Bridge newBridge;
         try {
-            newBridge = bridgeSupplier.get();
+            newBridge = bridgeData.creator.get();
         }
         catch (Throwable ex) {
             Debug.echoError("Cannot load Depenizen bridge for '" + name + "': fundamental loading error:");
@@ -132,7 +143,7 @@ public class Depenizen extends JavaPlugin {
         registerBridge("PlotSquared", () -> new PlotSquaredBridge());
         registerBridge("PVPArena", () -> new PVPArenaBridge());
         registerBridge("PVPStats", () -> new PVPStatsBridge());
-        registerBridge("Quests", () -> new QuestsBridge());
+        registerBridge("Quests", "me.pikamug.quests.Quests", () -> new QuestsBridge());
         registerBridge("Residence", () -> new ResidenceBridge());
         registerBridge("Sentinel", () -> new SentinelBridge());
         registerBridge("Shopkeepers", () -> new ShopkeepersBridge());
@@ -149,6 +160,10 @@ public class Depenizen extends JavaPlugin {
     }
 
     public void registerBridge(String name, Supplier<Bridge> bridgeSupplier) {
-        allBridges.put(name, bridgeSupplier);
+        registerBridge(name, null, bridgeSupplier);
+    }
+
+    public void registerBridge(String name, String classCheck, Supplier<Bridge> bridgeSupplier) {
+        allBridges.put(name, new BridgeData(classCheck, bridgeSupplier));
     }
 }


### PR DESCRIPTION
Reported on [Discord](https://discord.com/channels/315163488085475337/1298331671703064666).

## Addtions

- `Depenizen.BridgeData` record - just holds a bridge supplier & the new class checks.
- new `registerBridge` overload that takes a `classCheck`.

## Changes

- `allBridges` now stores the new `BridgeData`, and all relevant methods take/pass it.
- `bridgeData.classCheck` is now checked in `loadBridge` if it exists, and stops loading the bridge if the class isn't found.
- The `Quests` bridge now has a class check of `me.pikamug.quests.Quests`.