### PR TITLE
WorldEdit Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <craftbukkit.version>1.21.5-R0.1-SNAPSHOT</craftbukkit.version>
-        <citizens.version>2.0.38-SNAPSHOT</citizens.version>
+        <craftbukkit.version>26.2-R0.1-SNAPSHOT</craftbukkit.version>
+        <citizens.version>2.0.43-SNAPSHOT</citizens.version>
         <denizen.version>1.3.1-SNAPSHOT</denizen.version>
         <BUILD_NUMBER>Unknown</BUILD_NUMBER>
     </properties>
@@ -375,7 +375,7 @@
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
-            <version>7.3.0-SNAPSHOT</version>
+            <version>7.4.4-SNAPSHOT</version>
             <scope>system</scope>
             <systemPath>${basedir}/lib/WorldEdit.jar</systemPath>
         </dependency>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/WorldEditBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/WorldEditBridge.java
@@ -1,11 +1,13 @@
 package com.denizenscript.depenizen.bukkit.bridges;
 
+import com.denizenscript.denizen.objects.CuboidTag;
+import com.denizenscript.denizen.objects.EllipsoidTag;
+import com.denizenscript.denizen.objects.PolygonTag;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.depenizen.bukkit.Bridge;
-import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.depenizen.bukkit.commands.worldedit.WorldEditCommand;
-import com.denizenscript.depenizen.bukkit.properties.worldedit.WorldEditPlayerProperties;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.denizenscript.depenizen.bukkit.properties.worldedit.WorldEditAreaContainmentExtensions;
+import com.denizenscript.depenizen.bukkit.properties.worldedit.WorldEditPlayerExtensions;
 
 public class WorldEditBridge extends Bridge {
 
@@ -15,6 +17,9 @@ public class WorldEditBridge extends Bridge {
     public void init() {
         instance = this;
         DenizenCore.commandRegistry.registerCommand(WorldEditCommand.class);
-        PropertyParser.registerProperty(WorldEditPlayerProperties.class, PlayerTag.class);
+        WorldEditAreaContainmentExtensions.register(CuboidTag.class, CuboidTag.tagProcessor);
+        WorldEditAreaContainmentExtensions.register(EllipsoidTag.class, EllipsoidTag.tagProcessor);
+        WorldEditAreaContainmentExtensions.register(PolygonTag.class, PolygonTag.tagProcessor);
+        WorldEditPlayerExtensions.register();
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/worldedit/WorldEditCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/worldedit/WorldEditCommand.java
@@ -93,7 +93,7 @@ public class WorldEditCommand extends AbstractCommand {
 
     public enum Action {CREATE_SCHEMATIC, COPY_TO_CLIPBOARD, PASTE}
 
-    public void autoExecute(ScriptEntry scriptEntry,
+    public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgName("action") @ArgLinear @ArgDefaultNull Action action,
                                    @ArgName("file") @ArgPrefixed @ArgDefaultNull ElementTag file,
                                    @ArgName("cuboid") @ArgPrefixed @ArgDefaultNull CuboidTag cuboid,
@@ -310,7 +310,7 @@ public class WorldEditCommand extends AbstractCommand {
     }
 
 
-    public CuboidRegion cuboidToWECuboid(CuboidTag cuboid) {
+    public static CuboidRegion cuboidToWECuboid(CuboidTag cuboid) {
         LocationTag top = cuboid.getHigh(0);
         LocationTag bottom = cuboid.getLow(0);
         BlockVector3 topVector = BlockVector3.at(top.getBlockX(), top.getBlockY(), top.getBlockZ());

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/worldedit/WorldEditCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/worldedit/WorldEditCommand.java
@@ -5,16 +5,13 @@ import com.denizenscript.denizen.objects.CuboidTag;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
-import com.denizenscript.denizencore.objects.Argument;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
-import com.sk89q.worldedit.EditSession;
-import com.sk89q.worldedit.EmptyClipboardException;
-import com.sk89q.worldedit.WorldEdit;
-import com.sk89q.worldedit.WorldEditException;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import com.sk89q.worldedit.*;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.entity.Player;
@@ -39,6 +36,7 @@ public class WorldEditCommand extends AbstractCommand {
         setName("worldedit");
         setSyntax("worldedit [create_schematic/copy_to_clipboard/paste] (file:<file path>) (cuboid:<cuboid>) (position:<location>) (rotate:<#>) (undoable) (noair)");
         setRequiredArguments(2, 7);
+        autoCompile();
     }
 
     // <--[command]
@@ -93,47 +91,224 @@ public class WorldEditCommand extends AbstractCommand {
     //
     // -->
 
-    private enum Action {CREATE_SCHEMATIC, COPY_TO_CLIPBOARD, PASTE}
+    public enum Action {CREATE_SCHEMATIC, COPY_TO_CLIPBOARD, PASTE}
 
-    @Override
-    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
-        for (Argument arg : scriptEntry) {
-            if (!scriptEntry.hasObject("position")
-                    && arg.matchesPrefix("position")) {
-                scriptEntry.addObject("position", arg.asType(LocationTag.class));
-            }
-            else if (!scriptEntry.hasObject("file")
-                    && arg.matchesPrefix("file")) {
-                scriptEntry.addObject("file", arg.asElement());
-            }
-            else if (!scriptEntry.hasObject("cuboid")
-                    && arg.matchesPrefix("cuboid")) {
-                scriptEntry.addObject("cuboid", arg.asType(CuboidTag.class));
-            }
-            else if (!scriptEntry.hasObject("noair")
-                    && arg.matches("noair")) {
-                scriptEntry.addObject("noair", new ElementTag(true));
-            }
-            else if (!scriptEntry.hasObject("undoable")
-                    && arg.matches("undoable")) {
-                scriptEntry.addObject("undoable", new ElementTag(true));
-            }
-            else if (!scriptEntry.hasObject("rotate")
-                    && arg.matchesPrefix("rotate")) {
-                scriptEntry.addObject("rotate", arg.asElement());
-            }
-            else if (!scriptEntry.hasObject("action")
-                    && arg.matchesEnum(Action.class)) {
-                scriptEntry.addObject("action", arg.asElement());
-            }
-            else {
-                arg.reportUnhandled();
-            }
+    public void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("action") @ArgLinear @ArgDefaultNull Action action,
+                                   @ArgName("file") @ArgPrefixed @ArgDefaultNull ElementTag file,
+                                   @ArgName("cuboid") @ArgPrefixed @ArgDefaultNull CuboidTag cuboid,
+                                   @ArgName("position") @ArgPrefixed @ArgDefaultNull LocationTag position,
+                                   @ArgName("rotate") @ArgPrefixed @ArgDefaultNull ElementTag rotate,
+                                   @ArgName("undoable") boolean undoable,
+                                   @ArgName("noair") boolean noAir) {
+        if (action == null) {
+            throw new InvalidArgumentsRuntimeException("Action not specified!");
         }
-        if (!scriptEntry.hasObject("action")) {
-            throw new InvalidArgumentsException("Action not specified!");
+        PlayerTag target = Utilities.getEntryPlayer(scriptEntry);
+        switch (action) {
+            case PASTE: {
+                if (file == null) {
+                    Debug.echoError("File path not specified.");
+                    return;
+                }
+                if (position == null) {
+                    Debug.echoError("Position not specified.");
+                    return;
+                }
+                File fileToLoad = new File(Denizen.getInstance().getDataFolder(), "schematics/" + file + ".schem");
+                if (!Utilities.canReadFile(fileToLoad)) {
+                    Debug.echoError("Cannot read from that file path due to security settings in Denizen/config.yml.");
+                    return;
+                }
+                if (!fileToLoad.exists()) {
+                    Debug.echoError("File not found.");
+                    return;
+                }
+                ClipboardFormat format = ClipboardFormats.findByFile(fileToLoad);
+                if (format == null) {
+                    Debug.echoError("File not found.");
+                    return;
+                }
+                Clipboard clipboard;
+                try {
+                    clipboard = format.getReader(new FileInputStream(fileToLoad)).read();
+                }
+                catch (IOException ex) {
+                    Debug.echoError(ex);
+                    return;
+                }
+                if (clipboard == null) {
+                    Debug.echoError("Clipboard became null.");
+                    return;
+                }
+                ClipboardHolder holder = new ClipboardHolder(clipboard);
+                if (rotate != null) {
+                    holder.setTransform(holder.getTransform().combine(new AffineTransform().rotateY(rotate.asInt())));
+                }
+                World weWorld = new BukkitWorld(position.getWorld());
+                if (undoable) {
+                    if (target == null) {
+                        Debug.echoError("Player not found in queue.");
+                        return;
+                    }
+                    Player wePlayer = BukkitAdapter.adapt(target.getPlayerEntity());
+                    EditSession editSession = WorldEdit.getInstance().newEditSessionBuilder().world(weWorld).actor(wePlayer).build();
+                    Operation operation = holder.createPaste(editSession)
+                            .to(BlockVector3.at(position.getBlockX(), position.getBlockY(), position.getBlockZ()))
+                            .ignoreAirBlocks(noAir).build();
+                    try {
+                        Operations.complete(operation);
+                    }
+                    catch (WorldEditException ex) {
+                        Debug.echoError("Exception in WorldEdit while loading a schematic to clipboard.");
+                        Debug.echoError(ex);
+                        return;
+                    }
+                    Operations.completeBlindly(editSession.commit());
+                    WorldEdit.getInstance().getSessionManager().get(wePlayer).remember(editSession);
+                }
+                else {
+                    EditSession editSession = WorldEdit.getInstance().newEditSessionBuilder().world(weWorld).build();
+                    Operation operation = holder.createPaste(editSession)
+                            .to(BlockVector3.at(position.getBlockX(), position.getBlockY(), position.getBlockZ()))
+                            .ignoreAirBlocks(noAir).build();
+                    try {
+                        Operations.complete(operation);
+                    }
+                    catch (WorldEditException ex) {
+                        Debug.echoError("Exception in WorldEdit while loading a schematic to clipboard.");
+                        Debug.echoError(ex);
+                        return;
+                    }
+                    Operations.completeBlindly(editSession.commit());
+                }
+            }
+            case CREATE_SCHEMATIC: {
+                if (file == null) {
+                    Debug.echoError("File not specified.");
+                    return;
+                }
+                File fileToSave = new File(Denizen.getInstance().getDataFolder(), "schematics/" + file + ".schem");
+                if (!Utilities.canWriteToFile(fileToSave)) {
+                    Debug.echoError("Cannot write to that file path due to security settings in Denizen/config.yml.");
+                    return;
+                }
+                if (cuboid == null) {
+                    if (target == null) {
+                        Debug.echoError("Cuboid not specified.");
+                        return;
+                    }
+                    try {
+                        ClipboardHolder clipboard = WorldEdit.getInstance().getSessionManager().get(BukkitAdapter.adapt(target.getPlayerEntity())).getClipboard();
+                        try (ClipboardWriter writer = BuiltInClipboardFormat.SPONGE_SCHEMATIC.getWriter(new FileOutputStream(fileToSave))) {
+                            writer.write(clipboard.getClipboard());
+                        }
+                        catch (IOException ex) {
+                            Debug.echoError(ex);
+                        }
+                    }
+                    catch (EmptyClipboardException ex) {
+                        Debug.echoError("Cuboid not specified, and player does not have a clipboard.");
+                        return;
+                    }
+                    return;
+                }
+                CuboidRegion region = cuboidToWECuboid(cuboid);
+                if (position == null) {
+                    Debug.echoError("Position not specified.");
+                    return;
+                }
+                BlockArrayClipboard clipboard = new BlockArrayClipboard(region);
+                clipboard.setOrigin(BlockVector3.at(position.getBlockX(), position.getBlockY(), position.getBlockZ()));
+                EditSession editSession = WorldEdit.getInstance().newEditSessionBuilder().world(region.getWorld()).maxBlocks(-1).build();
+                ForwardExtentCopy forwardExtentCopy = new ForwardExtentCopy(editSession, region, clipboard, region.getMinimumPoint());
+                forwardExtentCopy.setCopyingEntities(false);
+                try {
+                    Operations.complete(forwardExtentCopy);
+                }
+                catch (WorldEditException ex) {
+                    Debug.echoError("Exception in WorldEdit while loading a schematic to clipboard.");
+                    Debug.echoError(ex);
+                    return;
+                }
+                try (ClipboardWriter writer = BuiltInClipboardFormat.SPONGE_SCHEMATIC.getWriter(new FileOutputStream(fileToSave))) {
+                    writer.write(clipboard);
+                }
+                catch (IOException ex) {
+                    Debug.echoError(ex);
+                }
+            }
+            case COPY_TO_CLIPBOARD: {
+                if (target == null) {
+                    Debug.echoError("Player not found in queue.");
+                    return;
+                }
+                if (file != null && cuboid != null) {
+                    Debug.echoError("Both cuboid and file args were specified. Only one can be used.");
+                    return;
+                }
+                if (cuboid != null) {
+                    if (position == null) {
+                        Debug.echoError("Position not specified.");
+                        return;
+                    }
+                    CuboidRegion region = cuboidToWECuboid(cuboid);
+                    Player player = BukkitAdapter.adapt(target.getPlayerEntity());
+                    BlockArrayClipboard clipboard = new BlockArrayClipboard(region);
+                    BlockVector3 pos = BlockVector3.at(position.getBlockX(), position.getBlockY(), position.getBlockZ());
+                    clipboard.setOrigin(pos);
+                    EditSession editSession = WorldEdit.getInstance().newEditSessionBuilder().world(region.getWorld()).maxBlocks(-1).actor(player).build();
+                    ForwardExtentCopy forwardExtentCopy = new ForwardExtentCopy(editSession, region, clipboard, region.getMinimumPoint());
+                    forwardExtentCopy.setCopyingEntities(false);
+                    try {
+                        Operations.complete(forwardExtentCopy);
+                    }
+                    catch (WorldEditException ex) {
+                        Debug.echoError("Exception in WorldEdit while loading a schematic to clipboard.");
+                        Debug.echoError(ex);
+                        return;
+                    }
+                    WorldEdit.getInstance().getSessionManager().get(player).setClipboard(new ClipboardHolder(clipboard));
+                    return;
+                }
+                if (file == null) {
+                    Debug.echoError("Cuboid or file must be specified.");
+                    return;
+                }
+                File fileToLoad = new File(Denizen.getInstance().getDataFolder(), "schematics/" + file + ".schem");
+                if (!Utilities.canReadFile(fileToLoad)) {
+                    Debug.echoError("Cannot read from that file path due to security settings in Denizen/config.yml.");
+                    return;
+                }
+                if (!fileToLoad.exists()) {
+                    Debug.echoError("File not found.");
+                    return;
+                }
+                ClipboardFormat format = ClipboardFormats.findByFile(fileToLoad);
+                if (format == null) {
+                    Debug.echoError("File not found.");
+                    return;
+                }
+                Clipboard clipboard;
+                Closer closer = Closer.create();
+                try {
+                    FileInputStream fis = closer.register(new FileInputStream(fileToLoad));
+                    BufferedInputStream bis = closer.register(new BufferedInputStream(fis));
+                    clipboard = closer.register(format.getReader(bis)).read();
+                }
+                catch (IOException ex) {
+                    Debug.echoError(ex);
+                    return;
+                }
+                if (clipboard == null) {
+                    Debug.echoError("Clipboard returned null.");
+                    return;
+                }
+                WorldEdit.getInstance().getSessionManager().get(BukkitAdapter.adapt(target.getPlayerEntity())).setClipboard(new ClipboardHolder(clipboard));
+            }
         }
     }
+
 
     public CuboidRegion cuboidToWECuboid(CuboidTag cuboid) {
         LocationTag top = cuboid.getHigh(0);
@@ -142,231 +317,5 @@ public class WorldEditCommand extends AbstractCommand {
         BlockVector3 bottomVector = BlockVector3.at(bottom.getBlockX(), bottom.getBlockY(), bottom.getBlockZ());
         World w = new BukkitWorld(cuboid.getWorld().getWorld());
         return new CuboidRegion(w, bottomVector, topVector);
-    }
-
-    @Override
-    public void execute(ScriptEntry scriptEntry) {
-        ElementTag action = scriptEntry.getObjectTag("action");
-        ElementTag file = scriptEntry.getObjectTag("file");
-        LocationTag position = scriptEntry.getObjectTag("position");
-        ElementTag noAir = scriptEntry.getObjectTag("noair");
-        CuboidTag cuboid = scriptEntry.getObjectTag("cuboid");
-        ElementTag undoable = scriptEntry.getObjectTag("undoable");
-        ElementTag rotate = scriptEntry.getObjectTag("rotate");
-        if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), action, file, position, noAir, cuboid, undoable, rotate);
-        }
-        PlayerTag target = Utilities.getEntryPlayer(scriptEntry);
-        if (action.asString().equalsIgnoreCase("paste")) {
-            if (file == null) {
-                Debug.echoError("File path not specified");
-                return;
-            }
-            if (position == null) {
-                Debug.echoError("Position not specified");
-                return;
-            }
-            File fileToLoad = new File(Denizen.getInstance().getDataFolder(), "schematics/" + file + ".schem");
-            if (!Utilities.canReadFile(fileToLoad)) {
-                Debug.echoError("Cannot read from that file path due to security settings in Denizen/config.yml.");
-                return;
-            }
-            if (!fileToLoad.exists()) {
-                Debug.echoError("File not found");
-                return;
-            }
-            ClipboardFormat format = ClipboardFormats.findByFile(fileToLoad);
-            if (format == null) {
-                Debug.echoError("File not found");
-                return;
-            }
-            Clipboard clipboard;
-            try {
-                ClipboardReader reader = format.getReader(new FileInputStream(fileToLoad));
-                clipboard = reader.read();
-            }
-            catch (IOException ex) {
-                Debug.echoError(ex);
-                return;
-            }
-            if (clipboard == null) {
-                Debug.echoError("Clipboard became null");
-                return;
-            }
-            ClipboardHolder holder = new ClipboardHolder(clipboard);
-            if (rotate != null) {
-                AffineTransform transform = new AffineTransform();
-                transform = transform.rotateY(rotate.asInt());
-                holder.setTransform(holder.getTransform().combine(transform));
-            }
-            World weWorld = new BukkitWorld(position.getWorld());
-            if (undoable != null) {
-                if (target == null) {
-                    Debug.echoError("Player not found in queue");
-                    return;
-                }
-                Player wePlayer = BukkitAdapter.adapt(target.getPlayerEntity());
-                EditSession editSession = WorldEdit.getInstance().newEditSessionBuilder().world(weWorld).actor(wePlayer).build();
-                Operation operation = holder.createPaste(editSession)
-                        .to(BlockVector3.at(position.getBlockX(), position.getBlockY(), position.getBlockZ()))
-                        .ignoreAirBlocks(noAir != null).build();
-                try {
-                    Operations.complete(operation);
-                }
-                catch (WorldEditException ex) {
-                    Debug.echoError("Exception in WorldEdit while loading a schematic to clipboard");
-                    Debug.echoError(ex);
-                    return;
-                }
-                Operations.completeBlindly(editSession.commit());
-                WorldEdit.getInstance().getSessionManager().get(wePlayer).remember(editSession);
-            }
-            else {
-                EditSession editSession = WorldEdit.getInstance().newEditSessionBuilder().world(weWorld).build();
-                Operation operation = holder.createPaste(editSession)
-                        .to(BlockVector3.at(position.getBlockX(), position.getBlockY(), position.getBlockZ()))
-                        .ignoreAirBlocks(noAir != null).build();
-                try {
-                    Operations.complete(operation);
-                }
-                catch (WorldEditException ex) {
-                    Debug.echoError("Exception in WorldEdit while loading a schematic to clipboard");
-                    Debug.echoError(ex);
-                    return;
-                }
-                Operations.completeBlindly(editSession.commit());
-            }
-        }
-        else if (action.asString().equalsIgnoreCase("create_schematic")) {
-            if (file == null) {
-                Debug.echoError("File not specified");
-                return;
-            }
-            File fileToSave = new File(Denizen.getInstance().getDataFolder(), "schematics/" + file + ".schem");
-            if (!Utilities.canWriteToFile(fileToSave)) {
-                Debug.echoError("Cannot write to that file path due to security settings in Denizen/config.yml.");
-                return;
-            }
-            if (cuboid == null) {
-                if (target == null) {
-                    Debug.echoError("Cuboid not specified");
-                    return;
-                }
-                Player wePlayer = BukkitAdapter.adapt(target.getPlayerEntity());
-                try {
-                    ClipboardHolder clipboard = WorldEdit.getInstance().getSessionManager().get(wePlayer).getClipboard();
-                    try (ClipboardWriter writer = BuiltInClipboardFormat.SPONGE_SCHEMATIC.getWriter(new FileOutputStream(fileToSave))) {
-                        writer.write(clipboard.getClipboard());
-                    }
-                    catch (IOException ex) {
-                        Debug.echoError(ex);
-                    }
-                }
-                catch (EmptyClipboardException ex) {
-                    Debug.echoError("Cuboid not specified, and player does not have a clipboard");
-                    return;
-                }
-                return;
-            }
-            CuboidRegion region = cuboidToWECuboid(cuboid);
-            if (position == null) {
-                Debug.echoError("Position not specified");
-                return;
-            }
-            BlockVector3 pos = BlockVector3.at(position.getBlockX(), position.getBlockY(), position.getBlockZ());
-            BlockArrayClipboard clipboard = new BlockArrayClipboard(region);
-            clipboard.setOrigin(pos);
-            EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(region.getWorld(), -1);
-            ForwardExtentCopy forwardExtentCopy = new ForwardExtentCopy(editSession, region, clipboard, region.getMinimumPoint());
-            forwardExtentCopy.setCopyingEntities(false);
-            try {
-                Operations.complete(forwardExtentCopy);
-            }
-            catch (WorldEditException ex) {
-                Debug.echoError("Exception in WorldEdit while loading a schematic to clipboard");
-                Debug.echoError(ex);
-                return;
-            }
-            try (ClipboardWriter writer = BuiltInClipboardFormat.SPONGE_SCHEMATIC.getWriter(new FileOutputStream(fileToSave))) {
-                writer.write(clipboard);
-            }
-            catch (IOException ex) {
-                Debug.echoError(ex);
-            }
-        }
-        else if (action.asString().equalsIgnoreCase("copy_to_clipboard")) {
-
-            if (target == null) {
-                Debug.echoError("Player not found in queue");
-                return;
-            }
-            if (file != null && cuboid != null) {
-                Debug.echoError("Both cuboid and file args were specified. Only one can be used.");
-                return;
-            }
-            if (cuboid != null) {
-                if (position == null) {
-                    Debug.echoError("Position not specified");
-                    return;
-                }
-                CuboidRegion region = cuboidToWECuboid(cuboid);
-                Player p = BukkitAdapter.adapt(target.getPlayerEntity());
-                BlockArrayClipboard clipboard = new BlockArrayClipboard(region);
-                BlockVector3 pos = BlockVector3.at(position.getBlockX(), position.getBlockY(), position.getBlockZ());
-                clipboard.setOrigin(pos);
-                EditSession editSession = WorldEdit.getInstance().getEditSessionFactory().getEditSession(region.getWorld(), -1, p);
-
-                ForwardExtentCopy forwardExtentCopy = new ForwardExtentCopy(editSession, region, clipboard, region.getMinimumPoint());
-                forwardExtentCopy.setCopyingEntities(false);
-                try {
-                    Operations.complete(forwardExtentCopy);
-                }
-                catch (WorldEditException ex) {
-                    Debug.echoError("Exception in WorldEdit while loading a schematic to clipboard");
-                    Debug.echoError(ex);
-                    return;
-                }
-                ClipboardHolder holder = new ClipboardHolder(clipboard);
-                WorldEdit.getInstance().getSessionManager().get(p).setClipboard(holder);
-                return;
-            }
-            if (file == null) {
-                Debug.echoError("Cuboid or file must be specified.");
-                return;
-            }
-            File fileToLoad = new File(Denizen.getInstance().getDataFolder(), "schematics/" + file + ".schem");
-            if (!Utilities.canReadFile(fileToLoad)) {
-                Debug.echoError("Cannot read from that file path due to security settings in Denizen/config.yml.");
-                return;
-            }
-            if (!fileToLoad.exists()) {
-                Debug.echoError("File not found");
-                return;
-            }
-            ClipboardFormat format = ClipboardFormats.findByFile(fileToLoad);
-            if (format == null) {
-                Debug.echoError("File not found");
-                return;
-            }
-            Clipboard clipboard;
-            Closer closer = Closer.create();
-            try {
-                FileInputStream fis = closer.register(new FileInputStream(fileToLoad));
-                BufferedInputStream bis = closer.register(new BufferedInputStream(fis));
-                ClipboardReader reader = closer.register(format.getReader(bis));
-                clipboard = reader.read();
-            }
-            catch (IOException ex) {
-                Debug.echoError(ex);
-                return;
-            }
-            if (clipboard == null) {
-                Debug.echoError("Clipboard returned null");
-                return;
-            }
-            ClipboardHolder holder = new ClipboardHolder(clipboard);
-            Player wePlayer = BukkitAdapter.adapt(target.getPlayerEntity());
-            WorldEdit.getInstance().getSessionManager().get(wePlayer).setClipboard(holder);
-        }
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/worldedit/WorldEditAreaContainmentExtensions.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/worldedit/WorldEditAreaContainmentExtensions.java
@@ -1,0 +1,53 @@
+package com.denizenscript.depenizen.bukkit.properties.worldedit;
+
+import com.denizenscript.denizen.objects.*;
+import com.denizenscript.denizencore.tags.ObjectTagProcessor;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.math.BlockVector2;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.math.Vector3;
+import com.sk89q.worldedit.regions.*;
+import com.sk89q.worldedit.world.World;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface WorldEditAreaContainmentExtensions {
+
+    static <T extends AreaContainmentObject> void register(Class<T> type, ObjectTagProcessor<T> processor) {
+
+        // <--[mechanism]
+        // @object AreaObject
+        // @name we_regenerate
+        // @plugin Depenizen, WorldEdit
+        // @input None
+        // @description
+        // Regenerates an area to its original state.
+        // -->
+        processor.registerMechanism("we_regenerate", false, (area, mechanism) -> {
+            World world = BukkitAdapter.adapt(area.getWorld().getWorld());
+            Region region;
+            if (area instanceof CuboidTag cuboid) {
+                LocationTag lowCorner = cuboid.pairs.get(0).low;
+                LocationTag highCorner = cuboid.pairs.get(0).high;
+                region = new CuboidRegion(world, BlockVector3.at(lowCorner.getX(), lowCorner.getY(), lowCorner.getZ()), BlockVector3.at(highCorner.getX(), highCorner.getY(), highCorner.getZ()));
+            }
+            else if (area instanceof EllipsoidTag ellipsoid) {
+                LocationTag center = ellipsoid.center;
+                LocationTag radius = ellipsoid.size;
+                region = new EllipsoidRegion(world, BlockVector3.at(center.getX(), center.getY(), center.getZ()), Vector3.at(radius.getX(), radius.getY(), radius.getZ()));
+            }
+            else if (area instanceof PolygonTag polygon) {
+                List<BlockVector2> points = new ArrayList<>();
+                for (PolygonTag.Corner corner : polygon.corners) {
+                    points.add(BlockVector2.at(corner.x, corner.z));
+                }
+                region = new Polygonal2DRegion(world, points, (int) Math.round(polygon.yMin), (int) Math.round(polygon.yMax));
+            }
+            else {
+                return;
+            }
+            world.regenerate(region, world);
+        });
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/worldedit/WorldEditAreaContainmentExtensions.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/worldedit/WorldEditAreaContainmentExtensions.java
@@ -23,31 +23,45 @@ public interface WorldEditAreaContainmentExtensions {
         // @input None
         // @description
         // Regenerates an area to its original state.
+        // Areas can be either CuboidTags, EllipsoidTags, or PolygonTags.
+        // Areas covering over 500,000 blocks run the risk of hanging your server and will not run. Use a mechanism value of 'force' to bypass this.
+        // @example
+        // # Regenerates a small area to its original state.
+        // - adjust <cuboid[world,1,1,1,10,10,10]> we_regenerate
+        // @example
+        // # Regenerates a large area to its original state.
+        // # NOTE: This runs the risk of hanging your server and should be avoided.
+        // - adjust <cuboid[world,1,1,1,100,100,100]> we_regenerate:force
         // -->
         processor.registerMechanism("we_regenerate", false, (area, mechanism) -> {
             World world = BukkitAdapter.adapt(area.getWorld().getWorld());
-            Region region;
+            Region region = null;
             if (area instanceof CuboidTag cuboid) {
                 LocationTag lowCorner = cuboid.pairs.get(0).low;
                 LocationTag highCorner = cuboid.pairs.get(0).high;
-                region = new CuboidRegion(world, BlockVector3.at(lowCorner.getX(), lowCorner.getY(), lowCorner.getZ()), BlockVector3.at(highCorner.getX(), highCorner.getY(), highCorner.getZ()));
+                region = new CuboidRegion(world, BlockVector3.at(lowCorner.getX(), lowCorner.getY(), lowCorner.getZ()),
+                                                BlockVector3.at(highCorner.getX(), highCorner.getY(), highCorner.getZ()));
             }
             else if (area instanceof EllipsoidTag ellipsoid) {
                 LocationTag center = ellipsoid.center;
                 LocationTag radius = ellipsoid.size;
-                region = new EllipsoidRegion(world, BlockVector3.at(center.getX(), center.getY(), center.getZ()), Vector3.at(radius.getX(), radius.getY(), radius.getZ()));
+                region = new EllipsoidRegion(world, BlockVector3.at(center.getX(), center.getY(), center.getZ()),
+                                                        Vector3.at(radius.getX(), radius.getY(), radius.getZ()));
             }
             else if (area instanceof PolygonTag polygon) {
-                List<BlockVector2> points = new ArrayList<>();
+                List<BlockVector2> points = new ArrayList<>(polygon.corners.size());
                 for (PolygonTag.Corner corner : polygon.corners) {
                     points.add(BlockVector2.at(corner.x, corner.z));
                 }
                 region = new Polygonal2DRegion(world, points, (int) Math.round(polygon.yMin), (int) Math.round(polygon.yMax));
             }
-            else {
-                return;
+            if (region.getVolume() <= 500000 || (mechanism.hasValue() && mechanism.getValue().asLowerString().equals("force"))) {
+                world.regenerate(region, world);
             }
-            world.regenerate(region, world);
+            else {
+                mechanism.echoError("This regeneration involves over 500,000 blocks and may hang your server. " +
+                        "If you want to do this, use 'we_regenerate:force'.");
+            }
         });
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/worldedit/WorldEditPlayerExtensions.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/worldedit/WorldEditPlayerExtensions.java
@@ -1,9 +1,8 @@
 package com.denizenscript.depenizen.bukkit.properties.worldedit;
 
 import com.denizenscript.denizen.objects.*;
-import com.denizenscript.denizencore.objects.properties.Property;
-import com.denizenscript.denizencore.objects.Mechanism;
-import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
 import com.denizenscript.denizencore.utilities.debugging.DebugInternals;
 import com.denizenscript.depenizen.bukkit.bridges.WorldEditBridge;
 import com.sk89q.worldedit.LocalSession;
@@ -22,52 +21,13 @@ import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
 import com.sk89q.worldedit.regions.selector.EllipsoidRegionSelector;
 import com.sk89q.worldedit.regions.selector.Polygonal2DRegionSelector;
 import com.sk89q.worldedit.world.item.ItemType;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizencore.objects.core.ListTag;
-import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.utilities.CoreUtilities;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.stream.Collectors;
 
-public class WorldEditPlayerProperties implements Property {
-
-    @Override
-    public String getPropertyString() {
-        return null;
-    }
-
-    @Override
-    public String getPropertyId() {
-        return "WorldEditPlayer";
-    }
-
-    public static boolean describes(ObjectTag object) {
-        return object instanceof PlayerTag
-                && ((PlayerTag) object).isOnline();
-    }
-
-    public static WorldEditPlayerProperties getFrom(ObjectTag object) {
-        if (!describes(object)) {
-            return null;
-        }
-        else {
-            return new WorldEditPlayerProperties((PlayerTag) object);
-        }
-    }
-
-    public static final String[] handledMechs = new String[] {
-            "we_selection"
-    };
-
-    public WorldEditPlayerProperties(PlayerTag player) {
-        this.player = player.getPlayerEntity();
-    }
-
-    Player player;
+public class WorldEditPlayerExtensions {
 
     public static Material deLegacy(Material mat) {
         if (mat.isLegacy()) {
@@ -89,27 +49,26 @@ public class WorldEditPlayerProperties implements Property {
         //
         // Note that some values may be listed as "unknown" or strange values due to WorldEdit having a messy API (no way to automatically stringify brush data).
         // -->
-        PropertyParser.registerTag(WorldEditPlayerProperties.class, ListTag.class, "we_brush_info", (attribute, object) -> {
+        PlayerTag.tagProcessor.registerTag(ListTag.class, "we_brush_info", (attribute, player) -> {
             WorldEditPlugin worldEdit = (WorldEditPlugin) WorldEditBridge.instance.plugin;
             ItemType itemType;
             if (attribute.hasParam()) {
-                itemType = BukkitAdapter.asItemType(deLegacy(attribute.paramAsType(ItemTag.class).getMaterial().getMaterial()));
+                itemType = BukkitAdapter.asItemType(deLegacy(attribute.paramAsType(ItemTag.class).getBukkitMaterial()));
             }
             else {
-                ItemStack itm = object.player.getEquipment().getItemInMainHand();
+                ItemStack itm = player.getPlayerEntity().getEquipment().getItemInMainHand();
                 itemType = BukkitAdapter.asItemType(deLegacy(itm == null ? Material.AIR : itm.getType()));
             }
-            Tool tool = worldEdit.getSession(object.player).getTool(itemType);
-            if (!(tool instanceof BrushTool)) {
+            Tool tool = worldEdit.getSession(player.getPlayerEntity()).getTool(itemType);
+            if (!(tool instanceof BrushTool brush)) {
                 return null;
             }
-            BrushTool brush = (BrushTool) tool;
             Brush btype = brush.getBrush();
             String brushType = CoreUtilities.toLowerCase(DebugInternals.getClassNameOpti(btype.getClass()));
             String materialInfo = "unknown";
             Pattern materialPattern = brush.getMaterial();
-            if (materialPattern instanceof BlockPattern) {
-                materialInfo = ((BlockPattern) materialPattern).getBlock().getAsString();
+            if (materialPattern instanceof BlockPattern blockPattern) {
+                materialInfo = blockPattern.getBlock().getAsString();
             }
             // TODO: other patterns?
             // TODO: mask?
@@ -123,23 +82,23 @@ public class WorldEditPlayerProperties implements Property {
 
         // <--[tag]
         // @attribute <PlayerTag.we_selection>
-        // @returns ObjectTag
+        // @returns AreaObject
         // @mechanism PlayerTag.we_selection
         // @plugin Depenizen, WorldEdit
         // @description
         // Returns the player's current block area selection, as a CuboidTag, EllipsoidTag, or PolygonTag.
         // -->
-        PropertyParser.registerTag(WorldEditPlayerProperties.class, ObjectTag.class, "we_selection", (attribute, object) -> {
+        PlayerTag.tagProcessor.registerTag(AreaContainmentObject.class, "we_selection", (attribute, player) -> {
             WorldEditPlugin worldEdit = (WorldEditPlugin) WorldEditBridge.instance.plugin;
-            RegionSelector selection = worldEdit.getSession(object.player).getRegionSelector(BukkitAdapter.adapt(object.player.getWorld()));
+            RegionSelector selection = worldEdit.getSession(player.getPlayerEntity()).getRegionSelector(BukkitAdapter.adapt(player.getWorld()));
             try {
                 if (selection != null && selection.isDefined()) {
-                    if (selection instanceof EllipsoidRegionSelector) {
-                        EllipsoidRegion region = ((EllipsoidRegionSelector) selection).getRegion();
+                    if (selection instanceof EllipsoidRegionSelector ellipsoid) {
+                        EllipsoidRegion region = ellipsoid.getRegion();
                         return new EllipsoidTag(new LocationTag(BukkitAdapter.adapt(BukkitAdapter.adapt(region.getWorld()), region.getCenter())), new LocationTag(BukkitAdapter.adapt(BukkitAdapter.adapt(region.getWorld()), region.getRadius())));
                     }
-                    else if (selection instanceof Polygonal2DRegionSelector) {
-                        Polygonal2DRegion region = ((Polygonal2DRegionSelector) selection).getRegion();
+                    else if (selection instanceof Polygonal2DRegionSelector polygonal) {
+                        Polygonal2DRegion region = polygonal.getRegion();
                         PolygonTag poly = new PolygonTag(new WorldTag(region.getWorld().getName()));
                         for (BlockVector2 vec2 : region.getPoints()) {
                             poly.corners.add(new PolygonTag.Corner(vec2.getX(), vec2.getZ()));
@@ -149,52 +108,48 @@ public class WorldEditPlayerProperties implements Property {
                         poly.recalculateBox();
                         return poly;
                     }
-                    return new CuboidTag(BukkitAdapter.adapt(object.player.getWorld(), selection.getIncompleteRegion().getMinimumPoint()),
-                            BukkitAdapter.adapt(object.player.getWorld(), selection.getIncompleteRegion().getMaximumPoint()));
+                    return new CuboidTag(BukkitAdapter.adapt(player.getWorld(), selection.getIncompleteRegion().getMinimumPoint()),
+                            BukkitAdapter.adapt(player.getWorld(), selection.getIncompleteRegion().getMaximumPoint()));
                 }
             }
             catch (Throwable ex) {
-                Debug.echoError(ex);
+                attribute.echoError(ex);
             }
             return null;
         }, "selected_region");
-    }
-
-    @Override
-    public void adjust(Mechanism mechanism) {
 
         // <--[mechanism]
         // @object PlayerTag
         // @name we_selection
         // @plugin Depenizen, WorldEdit
-        // @input ObjectTag
+        // @input AreaObject
         // @description
         // Sets the player's current block area selection, as a CuboidTag, EllipsoidTag, or PolygonTag.
         // @tags
         // <PlayerTag.we_selection>
         // -->
-        if (mechanism.matches("we_selection")) {
+        PlayerTag.tagProcessor.registerMechanism("we_selection", false, AreaContainmentObject.class, (player, mechanism, input) -> {
             WorldEditPlugin worldEdit = (WorldEditPlugin) WorldEditBridge.instance.plugin;
             RegionSelector selector;
-            if (mechanism.getValue().asString().startsWith("cu@")) {
-                CuboidTag input = mechanism.valueAsType(CuboidTag.class);
-                selector = new CuboidRegionSelector(BukkitAdapter.adapt(input.getWorld().getWorld()), BukkitAdapter.asBlockVector(input.getLow(0)), BukkitAdapter.asBlockVector(input.getHigh(0)));
+            if (input.canBeType(CuboidTag.class)) {
+                CuboidTag area = input.asType(CuboidTag.class, mechanism.context);
+                selector = new CuboidRegionSelector(BukkitAdapter.adapt(area.getWorld().getWorld()), BukkitAdapter.asBlockVector(area.getLow(0)), BukkitAdapter.asBlockVector(area.getHigh(0)));
             }
-            else if (mechanism.getValue().asString().startsWith("ellipsoid@")) {
-                EllipsoidTag input = mechanism.valueAsType(EllipsoidTag.class);
-                selector = new EllipsoidRegionSelector(BukkitAdapter.adapt(input.center.getWorld()), BukkitAdapter.asBlockVector(input.center), BukkitAdapter.asVector(input.size));
+            else if (input.canBeType(EllipsoidTag.class)) {
+                EllipsoidTag area = input.asType(EllipsoidTag.class, mechanism.context);
+                selector = new EllipsoidRegionSelector(BukkitAdapter.adapt(area.center.getWorld()), BukkitAdapter.asBlockVector(area.center), BukkitAdapter.asVector(area.size));
             }
-            else if (mechanism.getValue().asString().startsWith("polygon@")) {
-                PolygonTag input = mechanism.valueAsType(PolygonTag.class);
-                selector = new Polygonal2DRegionSelector(BukkitAdapter.adapt(input.world.getWorld()), input.corners.stream().map(c -> BlockVector2.at(c.x, c.z)).collect(Collectors.toList()), (int)input.yMin, (int)input.yMax);
+            else if (input.canBeType(PolygonTag.class)) {
+                PolygonTag area = input.asType(PolygonTag.class, mechanism.context);
+                selector = new Polygonal2DRegionSelector(BukkitAdapter.adapt(area.world.getWorld()), area.corners.stream().map(c -> BlockVector2.at(c.x, c.z)).collect(Collectors.toList()), (int) area.yMin, (int) area.yMax);
             }
             else {
-                Debug.echoError("Invalid we_selection input");
+                mechanism.echoError("Invalid we_selection input");
                 return;
             }
-            LocalSession session = worldEdit.getSession(player);
+            LocalSession session = worldEdit.getSession(player.getPlayerEntity());
             session.setRegionSelector(BukkitAdapter.adapt(player.getWorld()), selector);
-            selector.explainRegionAdjust(BukkitAdapter.adapt(player), session);
-        }
+            selector.explainRegionAdjust(BukkitAdapter.adapt(player.getPlayerEntity()), session);
+        });
     }
 }


### PR DESCRIPTION
- Added `AreaObject.we_regenerate` due to the deprecation of Denizen's `ChunkTag.regenerate` in 1.21
  - Works with CuboidTags, EllipsoidTags, and PolygonTags
- Updated WorldEdit from 1.20-1.20.4 version to 1.21.4-26.2 version
- Updated WorldEdit command and WorldEditPlayerProperties to modern version