### PR TITLE
`LuckPermsGroupTag.display_name` tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>me.lucko.luckperms</groupId>
             <artifactId>luckperms</artifactId>
-            <version>5.4.102</version>
+            <version>5.5.65</version>
             <scope>system</scope>
             <systemPath>${project.basedir}/lib/LuckPerms.jar</systemPath>
         </dependency>

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
@@ -108,6 +108,18 @@ public class LuckPermsGroupTag implements ObjectTag {
         });
 
         // <--[tag]
+        // @attribute <LuckPermsGroupTag.display_name>
+        // @returns ElementTag
+        // @plugin Depenizen, LuckPerms
+        // @description
+        // Returns the group's display name, if any.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "display_name", (attribute, object) -> {
+            String displayName = object.getGroup().getDisplayName();
+            return displayName != null ? new ElementTag(displayName, true) : null;
+        });
+
+        // <--[tag]
         // @attribute <LuckPermsGroupTag.group_prefix>
         // @returns ElementTag
         // @plugin Depenizen, LuckPerms


### PR DESCRIPTION
Adds a tag to get the display name of a LuckPerms group, if there is one that exists.

Requested at https://discord.com/channels/315163488085475337/1532357013865238678