### PR TITLE
LuckPerms Command

### DIFF
--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
@@ -1,10 +1,12 @@
 package com.denizenscript.depenizen.bukkit.bridges;
 
+import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.objects.ObjectFetcher;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.tags.PseudoObjectTagBase;
 import com.denizenscript.denizencore.tags.TagManager;
 import com.denizenscript.depenizen.bukkit.Bridge;
+import com.denizenscript.depenizen.bukkit.commands.luckperms.LuckPermsCommand;
 import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsGroupTag;
 import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsTrackTag;
 import com.denizenscript.depenizen.bukkit.properties.luckperms.LuckPermsPlayerExtensions;
@@ -65,6 +67,7 @@ public class LuckPermsBridge extends Bridge {
     @Override
     public void init() {
         luckPermsInstance = LuckPermsProvider.get();
+        DenizenCore.commandRegistry.registerCommand(LuckPermsCommand.class);
         LuckPermsPlayerExtensions.register();
         ObjectFetcher.registerWithObjectFetcher(LuckPermsGroupTag.class, LuckPermsGroupTag.tagProcessor);
         ObjectFetcher.registerWithObjectFetcher(LuckPermsTrackTag.class, LuckPermsTrackTag.tagProcessor);

--- a/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/bridges/LuckPermsBridge.java
@@ -2,6 +2,7 @@ package com.denizenscript.depenizen.bukkit.bridges;
 
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.objects.ObjectFetcher;
+import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.denizencore.tags.PseudoObjectTagBase;
 import com.denizenscript.denizencore.tags.TagManager;
@@ -12,6 +13,9 @@ import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsTrackTag;
 import com.denizenscript.depenizen.bukkit.properties.luckperms.LuckPermsPlayerExtensions;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.node.types.PermissionNode;
+
+import java.util.Collection;
 
 public class LuckPermsBridge extends Bridge {
 
@@ -83,5 +87,27 @@ public class LuckPermsBridge extends Bridge {
         TagManager.registerTagHandler(LuckPermsGroupTag.class, LuckPermsGroupTag.class, "luckperms_group", (attribute, param) -> {
             return param;
         });
+    }
+
+    public static DurationTag getPermissionExpiry(Collection<PermissionNode> nodes, String permission) {
+        PermissionNode bestNode = null;
+        int wildcardLevel = 0;
+        for (PermissionNode node : nodes) {
+            if (node.getKey().equalsIgnoreCase(permission)) {
+                bestNode = node;
+                break;
+            }
+            else if (node.isWildcard() && node.getWildcardLevel().isPresent()) {
+                int size = node.getKey().substring(0, node.getKey().length() - 1).length();
+                if (permission.length() < size || !permission.substring(0, size).equalsIgnoreCase(node.getKey().substring(0, size))) {
+                    continue;
+                }
+                if (node.getWildcardLevel().getAsInt() > wildcardLevel) {
+                    bestNode = node;
+                    wildcardLevel = node.getWildcardLevel().getAsInt();
+                }
+            }
+        }
+        return bestNode != null ? new DurationTag(bestNode.getExpiryDuration() != null ? (int) bestNode.getExpiryDuration().getSeconds() : 0) : null;
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/luckperms/LuckPermsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/luckperms/LuckPermsCommand.java
@@ -1,0 +1,133 @@
+package com.denizenscript.depenizen.bukkit.commands.luckperms;
+
+import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.*;
+import com.denizenscript.denizencore.scripts.ScriptEntry;
+import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.text.StringHolder;
+import com.denizenscript.depenizen.bukkit.bridges.LuckPermsBridge;
+import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsGroupTag;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.node.Node;
+import net.luckperms.api.node.NodeBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class LuckPermsCommand extends AbstractCommand {
+
+    public LuckPermsCommand() {
+        setName("luckperms");
+        setSyntax("luckperms [{set}/unset] [user:<player>/group:<group>] [permission] (state:{true}/false) (duration:<duration>) (contexts:<map>)");
+        setRequiredArguments(2, 6);
+        autoCompile();
+    }
+
+    // <--[command]
+    // @Name mcMMO
+    // @Syntax luckperms [{set}/unset] [user:<player>/group:<group>] [permission] (state:{true}/false) (duration:<duration>) (contexts:<map>)
+    // @Group Depenizen
+    // @Plugin Depenizen, mcMMO
+    // @Required 2
+    // @Maximum 6
+    // @Short Edits LuckPerms permissions.
+    //
+    // @Description
+    // This command allows you to add or unset permission nodes from players and LuckPerms groups.
+    //
+    // The 'duration' argument specifies how long a player or group will have the specified permission
+    // before it is removed. Not using this argument will result in the permission staying until manually removed.
+    //
+    // The 'contexts' argument sets the contexts in which the permission and state specified is active.
+    // Format is in MapTag format: 'type=value'.
+    // The 'value' accepts a ListTag for multiple entries of the same key.
+    //
+    // @Tags
+    // <PlayerTag.has_permission[<permission.node>]>
+    // <PlayerTag.luckperms_permission_expiry[<permission.node>]>
+    // <LuckPermsGroupTag.has_permission[<permission.node>]>
+    // <LuckPermsGroupTag.permission_expiry[<permission.node>]>
+    //
+    // @Usage
+    // Use to give a player the 'dscript.help' permission.
+    // - luckperms set user:<player> dscript.help state:true
+    //
+    // @Usage
+    // Use to give a player the 'dscript.warp' permission for 5 minutes in the main world.
+    // - luckperms user:<player> dscript.warp duration:5m contexts:[world=world]
+    //
+    // @Usage
+    // Use to disallow a group access to the 'dscript.spawn' permission in the nether and end.
+    // - luckperms group:<group> dscript.spawn state:false contexts:[dimension_type=the_nether|the_end]
+    //
+    // @Usage
+    // Use to unset the 'dscript.ban' permission back to the default for a player when in survival mode on the hub server.
+    // - luckperms unset user:<player> dscript.ban contexts:[gamemode=survival;server=hub]
+    //
+    // -->
+
+    public enum Action {SET, UNSET}
+
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("action") @ArgDefaultText("set") Action action,
+                                   @ArgName("user") @ArgPrefixed @ArgDefaultNull PlayerTag player,
+                                   @ArgName("group") @ArgPrefixed @ArgDefaultNull LuckPermsGroupTag group,
+                                   @ArgName("permission") @ArgLinear String permission,
+                                   @ArgName("state") @ArgPrefixed @ArgDefaultText("true") boolean state,
+                                   @ArgName("duration") @ArgPrefixed @ArgDefaultNull DurationTag duration,
+                                   @ArgName("contexts") @ArgPrefixed @ArgDefaultNull MapTag contexts) {
+        if (player == null && group == null) {
+            throw new InvalidArgumentsRuntimeException("Must specify either a player or a group!");
+        }
+        if (player != null && group != null) {
+            throw new InvalidArgumentsRuntimeException("Cannot specify both a player and a group!");
+        }
+        NodeBuilder<?, ?> nodeBuilder = Node.builder(permission).value(state);
+        if (duration != null) {
+            nodeBuilder = nodeBuilder.expiry((long) duration.getSeconds(), TimeUnit.SECONDS);
+        }
+        if (contexts != null) {
+            for (Map.Entry<StringHolder, ObjectTag> entry : contexts.entrySet()) {
+                for (String value : entry.getValue().asType(ListTag.class, scriptEntry.context)) {
+                    nodeBuilder = nodeBuilder.withContext(entry.getKey().low, value);
+                }
+            }
+        }
+        Node node = nodeBuilder.build();
+        switch (action) {
+            case SET: {
+                if (player != null) {
+                    User user = LuckPermsBridge.luckPermsInstance.getUserManager().getUser(player.getUUID());
+                    if (user == null) {
+                        throw new InvalidArgumentsRuntimeException("This user does not exist, have they joined the server before?");
+                    }
+                    user.data().add(node);
+                    LuckPermsBridge.luckPermsInstance.getUserManager().saveUser(user);
+                }
+                else {
+                    group.getGroup().data().add(node);
+                    LuckPermsBridge.luckPermsInstance.getGroupManager().saveGroup(group.getGroup());
+                }
+                break;
+            }
+            case UNSET: {
+                if (player != null) {
+                    User user = LuckPermsBridge.luckPermsInstance.getUserManager().getUser(player.getUUID());
+                    if (user == null) {
+                        throw new InvalidArgumentsRuntimeException("This user does not exist, have they joined the server before?");
+                    }
+                    user.data().remove(node);
+                    LuckPermsBridge.luckPermsInstance.getUserManager().saveUser(user);
+                }
+                else {
+                    group.getGroup().data().remove(node);
+                    LuckPermsBridge.luckPermsInstance.getGroupManager().saveGroup(group.getGroup());
+                }
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/com/denizenscript/depenizen/bukkit/commands/luckperms/LuckPermsCommand.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/commands/luckperms/LuckPermsCommand.java
@@ -7,6 +7,7 @@ import com.denizenscript.denizencore.objects.core.*;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.utilities.text.StringHolder;
 import com.denizenscript.depenizen.bukkit.bridges.LuckPermsBridge;
 import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsGroupTag;
@@ -14,6 +15,7 @@ import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.Node;
 import net.luckperms.api.node.NodeBuilder;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -21,14 +23,14 @@ public class LuckPermsCommand extends AbstractCommand {
 
     public LuckPermsCommand() {
         setName("luckperms");
-        setSyntax("luckperms [{set}/unset] [user:<player>/group:<group>] [permission] (state:{true}/false) (duration:<duration>) (contexts:<map>)");
+        setSyntax("luckperms ({set}/unset) [users:<player>|.../groups:<group>|...] [permission] (state:{true}/false) (duration:<duration>) (contexts:<map>)");
         setRequiredArguments(2, 6);
         autoCompile();
     }
 
     // <--[command]
     // @Name mcMMO
-    // @Syntax luckperms [{set}/unset] [user:<player>/group:<group>] [permission] (state:{true}/false) (duration:<duration>) (contexts:<map>)
+    // @Syntax luckperms ({set}/unset) [users:<player>|.../groups:<group>|...] [permission] (state:{true}/false) (duration:<duration>) (contexts:<map>)
     // @Group Depenizen
     // @Plugin Depenizen, mcMMO
     // @Required 2
@@ -47,25 +49,25 @@ public class LuckPermsCommand extends AbstractCommand {
     //
     // @Tags
     // <PlayerTag.has_permission[<permission.node>]>
-    // <PlayerTag.luckperms_permission_expiry[<permission.node>]>
+    // <PlayerTag.luckperms_permission_expiration[<permission.node>]>
     // <LuckPermsGroupTag.has_permission[<permission.node>]>
-    // <LuckPermsGroupTag.permission_expiry[<permission.node>]>
+    // <LuckPermsGroupTag.permission_expiration[<permission.node>]>
     //
     // @Usage
-    // Use to give a player the 'dscript.help' permission.
-    // - luckperms set user:<player> dscript.help state:true
+    // Use to give two players the 'dscript.help' permission.
+    // - luckperms set users:<[player]>|<[other_player]> dscript.help state:true
     //
     // @Usage
     // Use to give a player the 'dscript.warp' permission for 5 minutes in the main world.
-    // - luckperms user:<player> dscript.warp duration:5m contexts:[world=world]
+    // - luckperms users:<player> dscript.warp duration:5m contexts:[world=world]
     //
     // @Usage
-    // Use to disallow a group access to the 'dscript.spawn' permission in the nether and end.
-    // - luckperms group:<group> dscript.spawn state:false contexts:[dimension_type=the_nether|the_end]
+    // Use to disallow two groups access to the 'dscript.spawn' permission in the nether and end.
+    // - luckperms groups:<[group]>|<[other_group]> dscript.spawn state:false contexts:[dimension_type=the_nether|the_end]
     //
     // @Usage
     // Use to unset the 'dscript.ban' permission back to the default for a player when in survival mode on the hub server.
-    // - luckperms unset user:<player> dscript.ban contexts:[gamemode=survival;server=hub]
+    // - luckperms unset users:<player> dscript.ban contexts:[gamemode=survival;server=hub]
     //
     // -->
 
@@ -73,17 +75,17 @@ public class LuckPermsCommand extends AbstractCommand {
 
     public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgName("action") @ArgDefaultText("set") Action action,
-                                   @ArgName("user") @ArgPrefixed @ArgDefaultNull PlayerTag player,
-                                   @ArgName("group") @ArgPrefixed @ArgDefaultNull LuckPermsGroupTag group,
+                                   @ArgName("user") @ArgPrefixed @ArgDefaultNull @ArgSubType(PlayerTag.class) List<PlayerTag> players,
+                                   @ArgName("group") @ArgPrefixed @ArgDefaultNull @ArgSubType(LuckPermsGroupTag.class) List<LuckPermsGroupTag> groups,
                                    @ArgName("permission") @ArgLinear String permission,
                                    @ArgName("state") @ArgPrefixed @ArgDefaultText("true") boolean state,
                                    @ArgName("duration") @ArgPrefixed @ArgDefaultNull DurationTag duration,
                                    @ArgName("contexts") @ArgPrefixed @ArgDefaultNull MapTag contexts) {
-        if (player == null && group == null) {
-            throw new InvalidArgumentsRuntimeException("Must specify either a player or a group!");
+        if (players == null && groups == null) {
+            throw new InvalidArgumentsRuntimeException("Must specify either players or groups!");
         }
-        if (player != null && group != null) {
-            throw new InvalidArgumentsRuntimeException("Cannot specify both a player and a group!");
+        if (players != null && groups != null) {
+            throw new InvalidArgumentsRuntimeException("Cannot specify both players and groups!");
         }
         NodeBuilder<?, ?> nodeBuilder = Node.builder(permission).value(state);
         if (duration != null) {
@@ -99,34 +101,42 @@ public class LuckPermsCommand extends AbstractCommand {
         Node node = nodeBuilder.build();
         switch (action) {
             case SET: {
-                if (player != null) {
-                    User user = LuckPermsBridge.luckPermsInstance.getUserManager().getUser(player.getUUID());
-                    if (user == null) {
-                        throw new InvalidArgumentsRuntimeException("This user does not exist, have they joined the server before?");
+                if (players != null) {
+                    for (PlayerTag player : players) {
+                        User user = LuckPermsBridge.luckPermsInstance.getUserManager().getUser(player.getUUID());
+                        if (user == null) {
+                            Debug.echoError("User " + player.getUUID() + " does not exist, have they joined the server before?");
+                            continue;
+                        }
+                        user.data().add(node);
+                        LuckPermsBridge.luckPermsInstance.getUserManager().saveUser(user);
                     }
-                    user.data().add(node);
-                    LuckPermsBridge.luckPermsInstance.getUserManager().saveUser(user);
                 }
                 else {
-                    group.getGroup().data().add(node);
-                    LuckPermsBridge.luckPermsInstance.getGroupManager().saveGroup(group.getGroup());
+                    for (LuckPermsGroupTag group : groups) {
+                        group.getGroup().data().add(node);
+                        LuckPermsBridge.luckPermsInstance.getGroupManager().saveGroup(group.getGroup());
+                    }
                 }
-                break;
             }
             case UNSET: {
-                if (player != null) {
-                    User user = LuckPermsBridge.luckPermsInstance.getUserManager().getUser(player.getUUID());
-                    if (user == null) {
-                        throw new InvalidArgumentsRuntimeException("This user does not exist, have they joined the server before?");
+                if (players != null) {
+                    for (PlayerTag player : players) {
+                        User user = LuckPermsBridge.luckPermsInstance.getUserManager().getUser(player.getUUID());
+                        if (user == null) {
+                            Debug.echoError("User " + player.getUUID() + " does not exist, have they joined the server before?");
+                            continue;
+                        }
+                        user.data().remove(node);
+                        LuckPermsBridge.luckPermsInstance.getUserManager().saveUser(user);
                     }
-                    user.data().remove(node);
-                    LuckPermsBridge.luckPermsInstance.getUserManager().saveUser(user);
                 }
                 else {
-                    group.getGroup().data().remove(node);
-                    LuckPermsBridge.luckPermsInstance.getGroupManager().saveGroup(group.getGroup());
+                    for (LuckPermsGroupTag group : groups) {
+                        group.getGroup().data().remove(node);
+                        LuckPermsBridge.luckPermsInstance.getGroupManager().saveGroup(group.getGroup());
+                    }
                 }
-                break;
             }
         }
     }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
@@ -2,12 +2,15 @@ package com.denizenscript.depenizen.bukkit.objects.luckperms;
 
 import com.denizenscript.denizencore.objects.Fetchable;
 import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.tags.Attribute;
 import com.denizenscript.denizencore.tags.ObjectTagProcessor;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.depenizen.bukkit.bridges.LuckPermsBridge;
 import net.luckperms.api.model.group.Group;
+import net.luckperms.api.node.NodeType;
+import net.luckperms.api.node.types.PermissionNode;
 
 import java.util.OptionalInt;
 
@@ -152,6 +155,37 @@ public class LuckPermsGroupTag implements ObjectTag {
         // -->
         tagProcessor.registerTag(ElementTag.class, ElementTag.class, "has_permission", (attribute, object, p) -> {
             return new ElementTag(object.getGroup().getCachedData().getPermissionData().checkPermission(p.asString()).asBoolean());
+        });
+
+        // <--[tag]
+        // @attribute <LuckPermsGroupTag.permission_expiry[<permission.node>]>
+        // @returns DurationTag
+        // @plugin Depenizen, LuckPerms
+        // @description
+        // Returns how long a group has a permission for.
+        // If the group does not have the specific permission set, this will return the time for the closest wildcard permission, if any.
+        // -->
+        tagProcessor.registerTag(DurationTag.class, ElementTag.class, "permission_expiry", (attribute, object, p) -> {
+            String permission = p.asString();
+            PermissionNode bestNode = null;
+            int wildcardLevel = 0;
+            for (PermissionNode node : object.getGroup().getNodes(NodeType.PERMISSION)) {
+                if (node.getKey().equalsIgnoreCase(permission)) {
+                    bestNode = node;
+                    break;
+                }
+                else if (node.isWildcard() && node.getWildcardLevel().isPresent()) {
+                    int size = node.getKey().substring(0, node.getKey().length() - 1).length();
+                    if (permission.length() < size || !permission.substring(0, size).equalsIgnoreCase(node.getKey().substring(0, size))) {
+                        continue;
+                    }
+                    if (node.getWildcardLevel().getAsInt() > wildcardLevel) {
+                        bestNode = node;
+                        wildcardLevel = node.getWildcardLevel().getAsInt();
+                    }
+                }
+            }
+            return bestNode != null ? new DurationTag(bestNode.getExpiryDuration() != null ? (int) bestNode.getExpiryDuration().getSeconds() : 0) : null;
         });
     }
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/objects/luckperms/LuckPermsGroupTag.java
@@ -10,7 +10,6 @@ import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.depenizen.bukkit.bridges.LuckPermsBridge;
 import net.luckperms.api.model.group.Group;
 import net.luckperms.api.node.NodeType;
-import net.luckperms.api.node.types.PermissionNode;
 
 import java.util.OptionalInt;
 
@@ -158,34 +157,15 @@ public class LuckPermsGroupTag implements ObjectTag {
         });
 
         // <--[tag]
-        // @attribute <LuckPermsGroupTag.permission_expiry[<permission.node>]>
+        // @attribute <LuckPermsGroupTag.permission_expiration[<permission.node>]>
         // @returns DurationTag
         // @plugin Depenizen, LuckPerms
         // @description
         // Returns how long a group has a permission for.
         // If the group does not have the specific permission set, this will return the time for the closest wildcard permission, if any.
         // -->
-        tagProcessor.registerTag(DurationTag.class, ElementTag.class, "permission_expiry", (attribute, object, p) -> {
-            String permission = p.asString();
-            PermissionNode bestNode = null;
-            int wildcardLevel = 0;
-            for (PermissionNode node : object.getGroup().getNodes(NodeType.PERMISSION)) {
-                if (node.getKey().equalsIgnoreCase(permission)) {
-                    bestNode = node;
-                    break;
-                }
-                else if (node.isWildcard() && node.getWildcardLevel().isPresent()) {
-                    int size = node.getKey().substring(0, node.getKey().length() - 1).length();
-                    if (permission.length() < size || !permission.substring(0, size).equalsIgnoreCase(node.getKey().substring(0, size))) {
-                        continue;
-                    }
-                    if (node.getWildcardLevel().getAsInt() > wildcardLevel) {
-                        bestNode = node;
-                        wildcardLevel = node.getWildcardLevel().getAsInt();
-                    }
-                }
-            }
-            return bestNode != null ? new DurationTag(bestNode.getExpiryDuration() != null ? (int) bestNode.getExpiryDuration().getSeconds() : 0) : null;
+        tagProcessor.registerTag(DurationTag.class, ElementTag.class, "permission_expiration", (attribute, object, p) -> {
+            return LuckPermsBridge.getPermissionExpiry(object.getGroup().getNodes(NodeType.PERMISSION), p.asString());
         });
     }
 

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/luckperms/LuckPermsPlayerExtensions.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/luckperms/LuckPermsPlayerExtensions.java
@@ -10,7 +10,6 @@ import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsTrackTag;
 import net.luckperms.api.model.group.Group;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.NodeType;
-import net.luckperms.api.node.types.PermissionNode;
 import net.luckperms.api.query.QueryOptions;
 import net.luckperms.api.track.Track;
 
@@ -71,38 +70,16 @@ public class LuckPermsPlayerExtensions {
         });
 
         // <--[tag]
-        // @attribute <PlayerTag.luckperms_permission_expiry[<permission.node>]>
+        // @attribute <PlayerTag.luckperms_permission_expiration[<permission.node>]>
         // @returns DurationTag
         // @plugin Depenizen, LuckPerms
         // @description
         // Returns how long a player has a permission for.
         // If the player does not have the specific permission set, this will return the time for the closest wildcard permission, if any.
         // -->
-        PlayerTag.tagProcessor.registerTag(DurationTag.class, ElementTag.class, "luckperms_permission_expiry", (attribute, player, param) -> {
+        PlayerTag.tagProcessor.registerTag(DurationTag.class, ElementTag.class, "luckperms_permission_expiration", (attribute, player, param) -> {
             User user = LuckPermsBridge.luckPermsInstance.getUserManager().getUser(player.getUUID());
-            if (user == null) {
-                return null;
-            }
-            String permission = param.asString();
-            PermissionNode bestNode = null;
-            int wildcardLevel = 0;
-            for (PermissionNode node : user.getNodes(NodeType.PERMISSION)) {
-                if (node.getKey().equalsIgnoreCase(permission)) {
-                    bestNode = node;
-                    break;
-                }
-                else if (node.isWildcard() && node.getWildcardLevel().isPresent()) {
-                    int size = node.getKey().substring(0, node.getKey().length() - 1).length();
-                    if (permission.length() < size || !permission.substring(0, size).equalsIgnoreCase(node.getKey().substring(0, size))) {
-                        continue;
-                    }
-                    if (node.getWildcardLevel().getAsInt() > wildcardLevel) {
-                        bestNode = node;
-                        wildcardLevel = node.getWildcardLevel().getAsInt();
-                    }
-                }
-            }
-            return bestNode != null ? new DurationTag(bestNode.getExpiryDuration() != null ? (int) bestNode.getExpiryDuration().getSeconds() : 0) : null;
+            return user != null ? LuckPermsBridge.getPermissionExpiry(user.getNodes(NodeType.PERMISSION), param.asString()) : null;
         });
     }
 }

--- a/src/main/java/com/denizenscript/depenizen/bukkit/properties/luckperms/LuckPermsPlayerExtensions.java
+++ b/src/main/java/com/denizenscript/depenizen/bukkit/properties/luckperms/LuckPermsPlayerExtensions.java
@@ -1,6 +1,8 @@
 package com.denizenscript.depenizen.bukkit.properties.luckperms;
 
 import com.denizenscript.denizen.objects.PlayerTag;
+import com.denizenscript.denizencore.objects.core.DurationTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.core.ListTag;
 import com.denizenscript.depenizen.bukkit.bridges.LuckPermsBridge;
 import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsGroupTag;
@@ -8,6 +10,7 @@ import com.denizenscript.depenizen.bukkit.objects.luckperms.LuckPermsTrackTag;
 import net.luckperms.api.model.group.Group;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.node.NodeType;
+import net.luckperms.api.node.types.PermissionNode;
 import net.luckperms.api.query.QueryOptions;
 import net.luckperms.api.track.Track;
 
@@ -67,5 +70,39 @@ public class LuckPermsPlayerExtensions {
             return new LuckPermsGroupTag(group);
         });
 
+        // <--[tag]
+        // @attribute <PlayerTag.luckperms_permission_expiry[<permission.node>]>
+        // @returns DurationTag
+        // @plugin Depenizen, LuckPerms
+        // @description
+        // Returns how long a player has a permission for.
+        // If the player does not have the specific permission set, this will return the time for the closest wildcard permission, if any.
+        // -->
+        PlayerTag.tagProcessor.registerTag(DurationTag.class, ElementTag.class, "luckperms_permission_expiry", (attribute, player, param) -> {
+            User user = LuckPermsBridge.luckPermsInstance.getUserManager().getUser(player.getUUID());
+            if (user == null) {
+                return null;
+            }
+            String permission = param.asString();
+            PermissionNode bestNode = null;
+            int wildcardLevel = 0;
+            for (PermissionNode node : user.getNodes(NodeType.PERMISSION)) {
+                if (node.getKey().equalsIgnoreCase(permission)) {
+                    bestNode = node;
+                    break;
+                }
+                else if (node.isWildcard() && node.getWildcardLevel().isPresent()) {
+                    int size = node.getKey().substring(0, node.getKey().length() - 1).length();
+                    if (permission.length() < size || !permission.substring(0, size).equalsIgnoreCase(node.getKey().substring(0, size))) {
+                        continue;
+                    }
+                    if (node.getWildcardLevel().getAsInt() > wildcardLevel) {
+                        bestNode = node;
+                        wildcardLevel = node.getWildcardLevel().getAsInt();
+                    }
+                }
+            }
+            return bestNode != null ? new DurationTag(bestNode.getExpiryDuration() != null ? (int) bestNode.getExpiryDuration().getSeconds() : 0) : null;
+        });
     }
 }


### PR DESCRIPTION
- Adds a command to adjust permissions specifically for LuckPerms. Vault's permission editing doesn't have API that would make negatory or temporary permissions clean, so this was the cleanest more useful option (requested at https://discord.com/channels/315163488085475337/1306569854299410443).
- Adds a DurationTag tag for how long a PlayerTag has a specific permission. If the player does not have the permission set specifically on them, this will check to see if there are any wildcard permissions that contain the permission. If not, will return null. Permissions from inherited sources (i.e. groups) are not included in this tag and will have to be checked separately.
- Adds a DurationTag tag for how long a LuckPermsGroupTag has a specific permission. If the group does not have the permission set specifically on it, this will check to see if there are any wildcard permissions that contain the permission. If not, will return null. Permissions from inherited sources (i.e. parent groups) are not included in this tag and will have to be checked separately.

Given the command gives the ability to set temporary permissions, having a tag to get their duration seems like it would be helpful to those using it.